### PR TITLE
Refactor presenter hex processing

### DIFF
--- a/src/presenter/struct_presenter.py
+++ b/src/presenter/struct_presenter.py
@@ -4,11 +4,73 @@ from tkinter import filedialog
 from config import get_string
 from model.input_field_processor import InputFieldProcessor
 
+
+class HexProcessingError(Exception):
+    """Custom exception for hex part processing errors."""
+
+    def __init__(self, kind: str, message: str):
+        super().__init__(message)
+        self.kind = kind
+
 class StructPresenter:
     def __init__(self, model, view=None):
         self.model = model
         self.view = view # This will be set by main.py after view is instantiated
         self.input_processor = InputFieldProcessor()
+
+    def _process_hex_parts(self, hex_parts, byte_order):
+        """Convert list of hex input parts to a hex string and debug lines."""
+        final_hex_parts = []
+        debug_bytes = []
+
+        for raw_part, expected_chars in hex_parts:
+            if not re.match(r"^[0-9a-fA-F]*$", raw_part):
+                raise HexProcessingError(
+                    "invalid_input",
+                    f"Input '{raw_part}' contains non-hexadecimal characters."
+                )
+
+            chunk_byte_size = expected_chars // 2
+
+            try:
+                padded_hex = self.input_processor.pad_hex_input(raw_part, chunk_byte_size)
+                int_value = int(padded_hex, 16) if padded_hex else 0
+            except ValueError:
+                raise HexProcessingError(
+                    "invalid_input",
+                    f"Could not convert '{raw_part}' to a number."
+                )
+
+            try:
+                max_val = (2 ** (chunk_byte_size * 8)) - 1
+                if int_value > max_val:
+                    raise HexProcessingError(
+                        "value_too_large",
+                        f"Value 0x{raw_part} is too large for a {chunk_byte_size}-byte field."
+                    )
+
+                bytes_for_chunk = int_value.to_bytes(chunk_byte_size, byteorder=byte_order)
+                final_hex_parts.append(bytes_for_chunk.hex())
+                debug_bytes.append(bytes_for_chunk)
+            except OverflowError:
+                raise HexProcessingError(
+                    "overflow_error",
+                    f"Value 0x{raw_part} is too large for a {chunk_byte_size}-byte field."
+                )
+            except HexProcessingError:
+                raise
+            except Exception as e:  # pragma: no cover - unexpected conversion error
+                raise HexProcessingError(
+                    "conversion_error",
+                    f"Error converting value 0x{raw_part} to bytes: {e}"
+                )
+
+        debug_lines = []
+        for i, chunk in enumerate(debug_bytes):
+            hex_chars = [f"{b:02x}" for b in chunk]
+            debug_lines.append(f"Box {i+1} ({len(chunk)} bytes): {' '.join(hex_chars)}")
+
+        return "".join(final_hex_parts), debug_lines
 
     def browse_file(self):
         file_path = filedialog.askopenfilename(
@@ -57,66 +119,24 @@ class StructPresenter:
             return
 
         hex_parts_with_expected_len = self.view.get_hex_input_parts()
-        
+
         # Determine the selected endianness for converting input values to bytes
         byte_order_str = self.view.get_selected_endianness()
         byte_order_for_conversion = 'little' if byte_order_str == "Little Endian" else 'big'
 
-        final_memory_hex_parts = []
-        debug_bytes_per_box = []  # 收集每個 box 的 bytes
-        for raw_part, expected_chars_in_box in hex_parts_with_expected_len:
-            # Validate input is hex
-            if not re.match(r"^[0-9a-fA-F]*$", raw_part):
-                self.view.show_error(get_string("dialog_invalid_input"),
-                                   f"Input '{raw_part}' contains non-hexadecimal characters.")
-                return
-            
-            # Determine the byte size of the current input chunk (e.g., 1, 4, or 8 bytes)
-            chunk_byte_size = expected_chars_in_box // 2
+        try:
+            hex_data, debug_lines = self._process_hex_parts(hex_parts_with_expected_len, byte_order_for_conversion)
+        except HexProcessingError as e:
+            title_map = {
+                "invalid_input": get_string("dialog_invalid_input"),
+                "value_too_large": get_string("dialog_value_too_large"),
+                "overflow_error": get_string("dialog_overflow_error"),
+                "conversion_error": get_string("dialog_conversion_error"),
+            }
+            self.view.show_error(title_map.get(e.kind, "Error"), str(e))
+            return
 
-            # 使用 InputFieldProcessor 進行左補0
-            try:
-                padded_hex = self.input_processor.pad_hex_input(raw_part, chunk_byte_size)
-                int_value = int(padded_hex, 16) if padded_hex else 0
-            except ValueError:
-                self.view.show_error(get_string("dialog_invalid_input"),
-                                   f"Could not convert '{raw_part}' to a number.")
-                return
-
-            # Convert integer value to bytes using the selected endianness
-            try:
-                max_val = (2**(chunk_byte_size * 8)) - 1
-                if int_value > max_val:
-                    self.view.show_error(get_string("dialog_value_too_large"),
-                                       f"Value 0x{raw_part} is too large for a {chunk_byte_size}-byte field.")
-                    return
-
-                bytes_for_chunk = int_value.to_bytes(chunk_byte_size, byteorder=byte_order_for_conversion)
-                final_memory_hex_parts.append(bytes_for_chunk.hex())
-                debug_bytes_per_box.append(bytes_for_chunk)
-            except OverflowError:
-                self.view.show_error(get_string("dialog_overflow_error"),
-                                   f"Value 0x{raw_part} is too large for a {chunk_byte_size}-byte field.")
-                return
-            except Exception as e:
-                self.view.show_error(get_string("dialog_conversion_error"),
-                                   f"Error converting value 0x{raw_part} to bytes: {e}")
-                return
-
-        # --- 新增：格式化 debug bytes 並顯示 ---
-        # 根據每個 input 欄位的實際 byte 數來顯示
-        debug_lines = []
-        for i, chunk_bytes in enumerate(debug_bytes_per_box):
-            # 將這個 chunk 的所有 bytes 轉成 hex 字串
-            hex_chars = []
-            for b in chunk_bytes:
-                hex_chars.append(f"{b:02x}")
-            debug_lines.append(f"Box {i+1} ({len(chunk_bytes)} bytes): {' '.join(hex_chars)}")
         self.view.show_debug_bytes(debug_lines)
-        # --- end debug ---
-
-        # Join all converted hex parts to form the complete hex_data string representing raw memory
-        hex_data = "".join(final_memory_hex_parts)
 
         # The model's parse_hex_data will then use bytes.fromhex(hex_data) to get raw memory bytes.
         # The model's int.from_bytes will then interpret these raw memory bytes using the selected byte_order.
@@ -156,75 +176,30 @@ class StructPresenter:
     def parse_manual_hex_data(self, hex_parts, struct_def, endian):
         """解析 MyStruct tab 的 hex 資料並顯示結果"""
         try:
-            # 取得 unit size 來計算每個 box 的 byte 數
             unit_size = self.view.get_selected_manual_unit_size()
             byte_order = 'little' if endian == "Little Endian" else 'big'
-            
-            # 使用與 .H 檔 tab 相同的 debug bytes 機制
-            final_memory_hex_parts = []
-            debug_bytes_per_box = []
-            
-            for raw_part, expected_chars_in_box in hex_parts:
-                # Validate input is hex
-                if not re.match(r"^[0-9a-fA-F]*$", raw_part):
-                    self.view.show_error("無效輸入", f"輸入 '{raw_part}' 包含非十六進位字元。")
-                    return
-                
-                # Determine the byte size of the current input chunk
-                chunk_byte_size = expected_chars_in_box // 2
 
-                # 使用 InputFieldProcessor 進行左補0
-                try:
-                    padded_hex = self.input_processor.pad_hex_input(raw_part, chunk_byte_size)
-                    int_value = int(padded_hex, 16) if padded_hex else 0
-                except ValueError:
-                    self.view.show_error("無效輸入", f"無法將 '{raw_part}' 轉換為數字。")
-                    return
-
-                # Convert integer value to bytes using the selected endianness
-                try:
-                    max_val = (2**(chunk_byte_size * 8)) - 1
-                    if int_value > max_val:
-                        self.view.show_error("數值過大", f"數值 0x{raw_part} 對於 {chunk_byte_size}-byte 欄位來說太大。")
-                        return
-
-                    bytes_for_chunk = int_value.to_bytes(chunk_byte_size, byteorder=byte_order)
-                    final_memory_hex_parts.append(bytes_for_chunk.hex())
-                    debug_bytes_per_box.append(bytes_for_chunk)
-                except OverflowError:
-                    self.view.show_error("溢位錯誤", f"數值 0x{raw_part} 對於 {chunk_byte_size}-byte 欄位來說太大。")
-                    return
-                except Exception as e:
-                    self.view.show_error("轉換錯誤", f"轉換數值 0x{raw_part} 到 bytes 時發生錯誤: {e}")
-                    return
-
-            # 格式化 debug bytes 並顯示（與 .H 檔 tab 相同的格式）
-            debug_lines = []
-            for i, chunk_bytes in enumerate(debug_bytes_per_box):
-                # 將這個 chunk 的所有 bytes 轉成 hex 字串
-                hex_chars = []
-                for b in chunk_bytes:
-                    hex_chars.append(f"{b:02x}")
-                debug_lines.append(f"Box {i+1} ({len(chunk_bytes)} bytes): {' '.join(hex_chars)}")
-            
-            # 使用與 .H 檔 tab 相同的 show_debug_bytes 方法
+            hex_data, debug_lines = self._process_hex_parts(hex_parts, byte_order)
             self.view.show_manual_debug_bytes(debug_lines)
-            
-            # 設定 model 的 manual struct
+
             self.model.set_manual_struct(struct_def['members'], struct_def['total_size'])
-            
-            # 計算 layout
             layout = self.model.calculate_manual_layout(struct_def['members'], struct_def['total_size'])
-            
-            # 連接所有 hex parts 形成完整的 hex_data
-            hex_data = "".join(final_memory_hex_parts)
-            
+
             # 解析 hex 資料
             parsed_values = self.model.parse_manual_hex_data(hex_data, byte_order, layout)
-            
+
             # 呼叫 view 的顯示方法
             self.view.show_manual_parsed_values(parsed_values, endian)
-            
+
+        except HexProcessingError as e:
+            title_map = {
+                "invalid_input": "無效輸入",
+                "value_too_large": "數值過大",
+                "overflow_error": "溢位錯誤",
+                "conversion_error": "轉換錯誤",
+            }
+            self.view.show_error(title_map.get(e.kind, "錯誤"), str(e))
+
         except Exception as e:
             self.view.show_error("解析錯誤", f"解析 hex 資料時發生錯誤: {e}")
             # 清空顯示

--- a/tests/test_struct_presenter.py
+++ b/tests/test_struct_presenter.py
@@ -1,6 +1,6 @@
 import unittest
 from unittest.mock import MagicMock
-from presenter.struct_presenter import StructPresenter
+from presenter.struct_presenter import StructPresenter, HexProcessingError
 
 class TestStructPresenter(unittest.TestCase):
     def setUp(self):
@@ -30,6 +30,18 @@ class TestStructPresenter(unittest.TestCase):
         self.presenter.on_export_manual_struct()
         self.model.export_manual_struct_to_h.assert_called_once()
         self.view.show_exported_struct.assert_called_once_with("struct ManualStruct { ... }")
+
+    def test_process_hex_parts(self):
+        hex_parts = [("1", 2), ("2", 2)]
+        hex_data, debug_lines = self.presenter._process_hex_parts(hex_parts, "big")
+        self.assertEqual(hex_data, "0102")
+        self.assertEqual(debug_lines[0], "Box 1 (1 bytes): 01")
+        self.assertEqual(debug_lines[1], "Box 2 (1 bytes): 02")
+
+    def test_process_hex_parts_invalid_input(self):
+        with self.assertRaises(HexProcessingError) as cm:
+            self.presenter._process_hex_parts([("zz", 2)], "big")
+        self.assertEqual(cm.exception.kind, "invalid_input")
 
 if __name__ == "__main__":
     unittest.main() 


### PR DESCRIPTION
## Summary
- centralize hex input handling in StructPresenter
- add `_process_hex_parts` helper
- update presenter methods to use helper
- test new helper logic

## Testing
- `pytest -q` *(fails: no display name and no $DISPLAY environment variable)*

------
https://chatgpt.com/codex/tasks/task_e_6873e80b69ec832694160f8f55f4d75d