### PR TITLE
Refactor layout architecture for future union support

### DIFF
--- a/src/model/__init__.py
+++ b/src/model/__init__.py
@@ -3,13 +3,20 @@
 
 from model.struct_model import StructModel, parse_struct_definition, calculate_layout
 from model.struct_parser import MemberDef, parse_member_line_v2, parse_struct_definition_v2
-from model.layout import LayoutCalculator, LayoutItem
+from model.layout import (
+    LayoutCalculator,
+    LayoutItem,
+    BaseLayoutCalculator,
+    StructLayoutCalculator,
+)
 
 __all__ = [
     'StructModel',
     'parse_struct_definition',
     'calculate_layout',
     'LayoutCalculator',
+    'BaseLayoutCalculator',
+    'StructLayoutCalculator',
     'LayoutItem',
     'MemberDef',
     'parse_member_line_v2',

--- a/src/model/layout.py
+++ b/src/model/layout.py
@@ -2,6 +2,7 @@
 
 from dataclasses import dataclass
 from typing import List, Tuple, Union
+from abc import ABC, abstractmethod
 
 
 # Based on a common 64-bit system (like GCC on x86-64)
@@ -46,8 +47,8 @@ class LayoutItem:
         return hasattr(self, key)
 
 
-class LayoutCalculator:
-    """Helper class for calculating struct memory layout."""
+class BaseLayoutCalculator(ABC):
+    """Abstract base class for layout calculators."""
 
     def __init__(self):
         self.layout: List[LayoutItem] = []
@@ -58,6 +59,18 @@ class LayoutCalculator:
         self.bitfield_unit_align = 0
         self.bitfield_bit_offset = 0
         self.bitfield_unit_offset = 0
+
+    @abstractmethod
+    def calculate(self, members: List[Union[Tuple[str, str], dict]]):
+        """Calculate layout for given members."""
+        raise NotImplementedError
+
+
+class StructLayoutCalculator(BaseLayoutCalculator):
+    """Helper class for calculating struct memory layout."""
+
+    def __init__(self):
+        super().__init__()
 
     def _get_type_size_and_align(self, mtype: str) -> Tuple[int, int]:
         """Return (size, alignment) for a given C type."""
@@ -217,4 +230,8 @@ class LayoutCalculator:
             )
         )
         self.current_offset += size
+
+
+# Maintain backward compatibility
+LayoutCalculator = StructLayoutCalculator
 

--- a/tests/test_layout_refactor.py
+++ b/tests/test_layout_refactor.py
@@ -1,0 +1,31 @@
+import os
+import sys
+import unittest
+
+# Add src to path to import the model
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+from model.layout import BaseLayoutCalculator, StructLayoutCalculator, LayoutCalculator
+
+class TestLayoutRefactor(unittest.TestCase):
+    def test_base_class_is_abstract(self):
+        with self.assertRaises(TypeError):
+            BaseLayoutCalculator()
+
+    def test_layout_alias(self):
+        self.assertIs(LayoutCalculator, StructLayoutCalculator)
+
+    def test_struct_layout_same_as_alias(self):
+        members = [("char", "a"), ("int", "b")]
+        calc_alias = LayoutCalculator()
+        calc_struct = StructLayoutCalculator()
+        layout1, total1, align1 = calc_alias.calculate(members)
+        layout2, total2, align2 = calc_struct.calculate(members)
+        self.assertEqual(total1, total2)
+        self.assertEqual(align1, align2)
+        tuple1 = [(i.name, i.offset, i.size) for i in layout1]
+        tuple2 = [(i.name, i.offset, i.size) for i in layout2]
+        self.assertEqual(tuple1, tuple2)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- introduce `BaseLayoutCalculator` abstract class
- implement `StructLayoutCalculator` and alias `LayoutCalculator`
- expose new classes from `model.__init__`
- add regression tests for the refactored layout module

## Testing
- `pytest tests/test_layout_refactor.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68749ae58adc832694c5bd5ca6ee4423