### PR TITLE
Prepare codebase for union parsing

### DIFF
--- a/src/model/__init__.py
+++ b/src/model/__init__.py
@@ -2,12 +2,18 @@
 # Contains data structures and business logic independent of UI
 
 from model.struct_model import StructModel, parse_struct_definition, calculate_layout
-from model.struct_parser import MemberDef, parse_member_line_v2, parse_struct_definition_v2
+from model.struct_parser import (
+    MemberDef,
+    parse_member_line_v2,
+    parse_struct_definition_v2,
+    parse_c_definition,
+)
 from model.layout import (
     LayoutCalculator,
     LayoutItem,
     BaseLayoutCalculator,
     StructLayoutCalculator,
+    UnionLayoutCalculator,
 )
 
 __all__ = [
@@ -17,8 +23,10 @@ __all__ = [
     'LayoutCalculator',
     'BaseLayoutCalculator',
     'StructLayoutCalculator',
+    'UnionLayoutCalculator',
     'LayoutItem',
     'MemberDef',
     'parse_member_line_v2',
     'parse_struct_definition_v2',
+    'parse_c_definition',
 ]

--- a/src/model/struct_model.py
+++ b/src/model/struct_model.py
@@ -14,12 +14,13 @@ from .struct_parser import parse_struct_definition, parse_member_line
 # parse_struct_definition 與 parse_member_line 已移至 ``struct_parser`` 模組，
 # 於此重新匯入以維持相容性。
 
-def calculate_layout(members):
-    """Calculates the memory layout of a struct, including padding and bit fields."""
+def calculate_layout(members, calculator_cls=None):
+    """Calculate the memory layout using the specified calculator class."""
     if not members:
         return [], 0, 1
 
-    layout_calculator = LayoutCalculator()
+    calculator_cls = calculator_cls or LayoutCalculator
+    layout_calculator = calculator_cls()
     return layout_calculator.calculate(members)
 
 

--- a/tests/test_union_preparation.py
+++ b/tests/test_union_preparation.py
@@ -1,0 +1,32 @@
+import unittest
+from model.struct_model import calculate_layout
+from model.layout import BaseLayoutCalculator, LayoutItem
+from model.struct_parser import parse_c_definition
+
+class DummyCalculator(BaseLayoutCalculator):
+    def calculate(self, members):
+        self.layout = [LayoutItem(name='dummy', type='char', size=1, offset=0, is_bitfield=False, bit_offset=0, bit_size=8)]
+        return self.layout, 1, 1
+
+class TestCalculateLayoutCustom(unittest.TestCase):
+    def test_custom_calculator_parameter(self):
+        layout, total, align = calculate_layout([('char', 'a')], calculator_cls=DummyCalculator)
+        self.assertEqual(total, 1)
+        self.assertEqual(align, 1)
+        self.assertEqual(layout[0].name, 'dummy')
+
+class TestParseCDefinition(unittest.TestCase):
+    def test_parse_struct_returns_kind(self):
+        content = """
+        struct A {
+            int x;
+        };
+        """
+        kind, name, members = parse_c_definition(content)
+        self.assertEqual(kind, 'struct')
+        self.assertEqual(name, 'A')
+        self.assertEqual(len(members), 1)
+        self.assertEqual(members[0], ('int', 'x'))
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `UnionLayoutCalculator` for future union support
- allow `calculate_layout` to accept a custom calculator class
- parameterize `_extract_struct_body` and add `parse_c_definition`
- expose new APIs via `model.__init__`
- test new behaviors in `test_union_preparation`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68749f1dabc88326ba7d57060d31a4b9