### PR TITLE
Prepare parser for nested struct/union support

### DIFF
--- a/src/model/__init__.py
+++ b/src/model/__init__.py
@@ -4,9 +4,13 @@
 from model.struct_model import StructModel, parse_struct_definition, calculate_layout
 from model.struct_parser import (
     MemberDef,
+    StructDef,
+    UnionDef,
     parse_member_line_v2,
     parse_struct_definition_v2,
+    parse_struct_definition_ast,
     parse_c_definition,
+    parse_c_definition_ast,
 )
 from model.layout import (
     LayoutCalculator,
@@ -26,7 +30,11 @@ __all__ = [
     'UnionLayoutCalculator',
     'LayoutItem',
     'MemberDef',
+    'StructDef',
+    'UnionDef',
     'parse_member_line_v2',
     'parse_struct_definition_v2',
+    'parse_struct_definition_ast',
     'parse_c_definition',
+    'parse_c_definition_ast',
 ]

--- a/tests/test_struct_parser_v2.py
+++ b/tests/test_struct_parser_v2.py
@@ -1,5 +1,19 @@
 import unittest
-from model.struct_parser import parse_member_line_v2, parse_struct_definition_v2, MemberDef
+import sys
+import os
+
+# Add project root to Python path
+project_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, os.path.join(project_root, 'src'))
+sys.path.insert(0, project_root)
+
+from model.struct_parser import (
+    parse_member_line_v2,
+    parse_struct_definition_v2,
+    parse_struct_definition_ast,
+    MemberDef,
+    StructDef,
+)
 from model.layout import LayoutCalculator
 
 class TestParseMemberLineV2(unittest.TestCase):
@@ -10,6 +24,7 @@ class TestParseMemberLineV2(unittest.TestCase):
         self.assertEqual(m.name, 'value')
         self.assertFalse(m.is_bitfield)
         self.assertEqual(m.array_dims, [])
+        self.assertIsNone(m.nested)
 
     def test_pointer_member(self):
         m = parse_member_line_v2('char* ptr')
@@ -37,6 +52,20 @@ class TestParseStructDefinitionV2(unittest.TestCase):
         self.assertEqual(len(members), 2)
         self.assertIsInstance(members[0], MemberDef)
 
+class TestParseStructDefinitionAst(unittest.TestCase):
+    def test_ast_return(self):
+        content = '''
+        struct Simple {
+            char a;
+            int b;
+        };
+        '''
+        sdef = parse_struct_definition_ast(content)
+        self.assertIsInstance(sdef, StructDef)
+        self.assertEqual(sdef.name, 'Simple')
+        self.assertEqual(len(sdef.members), 2)
+        self.assertIsInstance(sdef.members[0], MemberDef)
+
 class TestLayoutCalculatorWithMemberDef(unittest.TestCase):
     def test_layout_with_memberdef(self):
         members = [MemberDef('char', 'a'), MemberDef('int', 'b')]
@@ -51,3 +80,4 @@ class TestLayoutCalculatorWithMemberDef(unittest.TestCase):
 
 if __name__ == '__main__':
     unittest.main()
+


### PR DESCRIPTION
## Summary
- add `StructDef` and `UnionDef` dataclasses
- extend `MemberDef` with a `nested` attribute
- expose new parsing helpers and update module exports
- add tests for the new AST structures

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6874be5eaf6883268384d0e9a874c316