### PR TITLE
Refactor layout calculators for future pragma pack support

### DIFF
--- a/src/model/struct_model.py
+++ b/src/model/struct_model.py
@@ -14,13 +14,13 @@ from .struct_parser import parse_struct_definition, parse_member_line
 # parse_struct_definition 與 parse_member_line 已移至 ``struct_parser`` 模組，
 # 於此重新匯入以維持相容性。
 
-def calculate_layout(members, calculator_cls=None):
+def calculate_layout(members, calculator_cls=None, pack_alignment=None):
     """Calculate the memory layout using the specified calculator class."""
     if not members:
         return [], 0, 1
 
     calculator_cls = calculator_cls or LayoutCalculator
-    layout_calculator = calculator_cls()
+    layout_calculator = calculator_cls(pack_alignment=pack_alignment)
     return layout_calculator.calculate(members)
 
 

--- a/tests/test_pack_alignment_placeholder.py
+++ b/tests/test_pack_alignment_placeholder.py
@@ -1,0 +1,23 @@
+import unittest
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+from model.layout import LayoutCalculator
+
+class TestPackAlignmentPlaceholder(unittest.TestCase):
+    def test_pack_alignment_no_effect(self):
+        members = [("char", "a"), ("int", "b")]
+        calc_default = LayoutCalculator()
+        layout_default, total_default, align_default = calc_default.calculate(members)
+
+        calc_pack = LayoutCalculator(pack_alignment=1)
+        layout_pack, total_pack, align_pack = calc_pack.calculate(members)
+
+        self.assertEqual(layout_pack, layout_default)
+        self.assertEqual(total_pack, total_default)
+        self.assertEqual(align_pack, align_default)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `pack_alignment` parameter to `BaseLayoutCalculator` and subclasses
- use `_effective_alignment` when calculating padding
- allow `calculate_layout` to accept pack alignment
- test that specifying `pack_alignment` currently has no effect

## Testing
- `pytest -q tests/test_pack_alignment_placeholder.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68750858c33483269fa0a5eb18fd09d4