### PR TITLE
Fix MagicMock import for packaging

### DIFF
--- a/src/view/struct_view.py
+++ b/src/view/struct_view.py
@@ -1,7 +1,6 @@
 import tkinter as tk
 from tkinter import ttk
 from tkinter import filedialog, messagebox
-from unittest.mock import MagicMock
 # from config import get_string
 from model.struct_model import StructModel
 
@@ -53,6 +52,7 @@ class StructView(tk.Tk):
 
             self._create_tab_control()
         else:
+            from unittest.mock import MagicMock
             # When patched with a Mock object, create minimal attributes used in
             # tests without constructing real Tk widgets.
             self.presenter = presenter


### PR DESCRIPTION
## Summary
- avoid importing MagicMock at module load time in StructView

## Testing
- `python run_tests.py --all` *(fails: no display)*
- `PYTHONPATH=src python -m unittest tests.test_struct_presenter`
- `python packing/build.py --target macos` *(fails: non-macOS platform)*

------
https://chatgpt.com/codex/tasks/task_e_6876137e4b10832698aa12c9733f0ab5