### PR TITLE
Fix pyinstaller spec path in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
         
     - name: Create executable with PyInstaller
       run: |
-        pyinstaller CppStructParser.spec
+        pyinstaller packing/CppStructParser-windows.spec
         
     - name: Create Release
       id: create_release


### PR DESCRIPTION
## Summary
- correct spec path in the release workflow for creating Windows executable

## Testing
- `python run_tests.py --all` *(fails: no display name and one failing test)*

------
https://chatgpt.com/codex/tasks/task_e_6876137e449083268f76502b510b76bc