### PR TITLE
Implement nested union support

### DIFF
--- a/src/model/layout.py
+++ b/src/model/layout.py
@@ -193,7 +193,11 @@ class StructLayoutCalculator(BaseLayoutCalculator):
         nested = self._get_attr(member, "nested")
 
         if nested is not None:
-            calc = StructLayoutCalculator(pack_alignment=self.pack_alignment)
+            from .struct_parser import UnionDef
+            if isinstance(nested, UnionDef):
+                calc = UnionLayoutCalculator(pack_alignment=self.pack_alignment)
+            else:
+                calc = StructLayoutCalculator(pack_alignment=self.pack_alignment)
             nested_layout, nested_size, nested_align = calc.calculate(nested.members)
             if nested_align > self.max_alignment:
                 self.max_alignment = nested_align

--- a/src/model/struct_parser.py
+++ b/src/model/struct_parser.py
@@ -126,6 +126,18 @@ def parse_member_line_v2(line: str) -> Optional[MemberDef]:
                 array_dims=dims,
                 nested=struct_def,
             )
+    if line.startswith("union") and "{" in line and "}" in line:
+        union_def = parse_union_definition_ast(line + ";")
+        if union_def:
+            after = line[line.rfind("}") + 1 :].strip()
+            after = after.rstrip(";")
+            name, dims = _extract_array_dims(after) if after else (None, [])
+            return MemberDef(
+                type="union",
+                name=name,
+                array_dims=dims,
+                nested=union_def,
+            )
     return None
 
 

--- a/tests/test_struct_model.py
+++ b/tests/test_struct_model.py
@@ -378,6 +378,43 @@ class TestCalculateLayout(unittest.TestCase):
         self.assertEqual(total, 20)
         self.assertEqual(align, 4)
 
+    def test_calculate_layout_nested_union(self):
+        content = '''
+        struct Outer {
+            int a;
+            union U {
+                int x;
+                char y;
+            } u;
+        };
+        '''
+        sdef = parse_struct_definition_ast(content)
+        layout, total, align = calculate_layout(sdef.members)
+        names = [item.name for item in layout]
+        self.assertEqual(names, ["a", "u.x", "u.y"])
+        self.assertEqual(total, 8)
+        self.assertEqual(align, 4)
+
+    def test_calculate_layout_nested_union_array(self):
+        content = '''
+        struct Outer {
+            int a;
+            union U {
+                int x;
+                char y;
+            } u_arr[2];
+        };
+        '''
+        sdef = parse_struct_definition_ast(content)
+        layout, total, align = calculate_layout(sdef.members)
+        names = [item.name for item in layout]
+        self.assertEqual(
+            names,
+            ["a", "u_arr[0].x", "u_arr[0].y", "u_arr[1].x", "u_arr[1].y"]
+        )
+        self.assertEqual(total, 12)
+        self.assertEqual(align, 4)
+
 
 class TestStructModel(unittest.TestCase):
     """Test cases for StructModel class."""

--- a/tests/test_struct_parser_v2.py
+++ b/tests/test_struct_parser_v2.py
@@ -13,6 +13,7 @@ from model.struct_parser import (
     parse_struct_definition_ast,
     MemberDef,
     StructDef,
+    UnionDef,
 )
 from model.layout import LayoutCalculator
 
@@ -105,6 +106,45 @@ class TestParseStructDefinitionAst(unittest.TestCase):
         self.assertEqual(arr_member.array_dims, [2])
         self.assertIsNotNone(arr_member.nested)
         self.assertEqual(arr_member.nested.name, 'Inner')
+        self.assertEqual(len(arr_member.nested.members), 2)
+
+    def test_nested_union(self):
+        content = '''
+        struct Outer {
+            int a;
+            union U {
+                int x;
+                char y;
+            } u;
+        };
+        '''
+        sdef = parse_struct_definition_ast(content)
+        self.assertIsInstance(sdef, StructDef)
+        self.assertEqual(len(sdef.members), 2)
+        u_member = sdef.members[1]
+        self.assertEqual(u_member.name, 'u')
+        self.assertIsNotNone(u_member.nested)
+        self.assertIsInstance(u_member.nested, UnionDef)
+        self.assertEqual(len(u_member.nested.members), 2)
+
+    def test_nested_union_array(self):
+        content = '''
+        struct Outer {
+            int a;
+            union U {
+                int x;
+                char y;
+            } u_arr[2];
+        };
+        '''
+        sdef = parse_struct_definition_ast(content)
+        self.assertIsInstance(sdef, StructDef)
+        self.assertEqual(len(sdef.members), 2)
+        arr_member = sdef.members[1]
+        self.assertEqual(arr_member.name, 'u_arr')
+        self.assertEqual(arr_member.array_dims, [2])
+        self.assertIsNotNone(arr_member.nested)
+        self.assertIsInstance(arr_member.nested, UnionDef)
         self.assertEqual(len(arr_member.nested.members), 2)
 
 class TestLayoutCalculatorWithMemberDef(unittest.TestCase):


### PR DESCRIPTION
## Summary
- extend struct parser to handle nested unions
- choose correct layout calculator when encountering nested unions
- test nested union parsing and layout
- verify hex parsing for nested unions

## Testing
- `python run_all_tests.py`

------
https://chatgpt.com/codex/tasks/task_e_68763207a91883268853452b7d1eca0f