### PR TITLE
Add anonymous bitfield export support

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This project provides a graphical user interface (GUI) tool built with Python an
 
 - **Model (`src/model/`)**: Contains the core business logic, data structures, and data manipulation. It's independent of the UI.
   - `struct_model.py`: Handles parsing C++ struct definitions, calculating memory layouts (including padding), and interpreting raw hexadecimal data based on endianness.
-  - **Supports bitfield members** (e.g., `int a : 1;`) with proper packing and storage unit alignment.
+  - **Supports bitfield members** (including anonymous bitfields like `int : 1;`) with proper packing and storage unit alignment.
   - **Union parsing** with correct layout calculation.
   - **N-D array support** for parsing and layout of multi-dimensional arrays.
   - **Manual struct definition** with byte/bit size validation and export functionality.
@@ -131,7 +131,7 @@ This project provides a graphical user interface (GUI) tool built with Python an
   - The size and alignment of each member.
   - The required memory padding between members.
   - The final total size of the struct.
-- **Bitfield Support**: Full support for C/C++ bitfield members (e.g., `int a : 1;`) with proper packing and storage unit alignment.
+  - **Bitfield Support**: Full support for C/C++ bitfield members (including anonymous bitfields) with proper packing and storage unit alignment.
 - **Union Support**: Parses C `union` definitions with correct layout calculation.
 - **Manual Struct Definition**: Define structs directly in the GUI with byte/bit size validation and real-time remaining space display.
 - **Chunked Hexadecimal Data Input**: Allows inputting hex data in user-defined chunks (1, 4, or 8 bytes) for better readability and ease of entry.
@@ -148,7 +148,7 @@ This project provides a graphical user interface (GUI) tool built with Python an
 The application fully supports C/C++ bitfield members with the following features:
 
 ### Bitfield Parsing
-- Parses bitfield declarations like `int a : 1;` from C++ header files
+- Parses bitfield declarations like `int a : 1;` and anonymous forms `int : 1;` from C++ header files
 - Supports multiple bitfields in the same storage unit with proper bit offset calculation
 - Handles bitfield packing across storage unit boundaries
 

--- a/docs/architecture/STRUCT_PARSING.md
+++ b/docs/architecture/STRUCT_PARSING.md
@@ -5,7 +5,7 @@ This document explains how `struct_model.py` parses a C++ `struct` and computes 
 ## Overview
 - The parser is implemented in `src/model/struct_model.py`.
 - Supports both `struct` and `union` definitions.
-- **Supports bitfield members (e.g., `int a : 1;`), including bitfield packing and storage unit alignment.**
+- **Supports bitfield members (e.g., `int a : 1;`), including anonymous bitfields and storage unit alignment.**
 - **Supports multi-dimensional array members with proper layout calculation and data extraction.**
 - **Supports manual struct definition with byte/bit size validation and export functionality.**
 - **Implements comprehensive validation logic with TDD testing approach.**

--- a/docs/development/v5_unanomous_bitfield.md
+++ b/docs/development/v5_unanomous_bitfield.md
@@ -12,6 +12,7 @@
 4. `LayoutCalculator._add_bitfield_to_layout` 現已接受 `name=None`，並直接寫入 layout【F:src/model/layout.py†L292-L308】。
 5. `parse_hex_data` 在組合結果時使用 `item['name']`，若值為 `None` 仍能正常處理【F:src/model/struct_model.py†L93-L138】。
 6. `tests/test_struct_parser_utils.py` 中已包含解析匿名 bitfield 的測試並正常通過【F:tests/test_struct_parser_utils.py†L20-L26】。
+7. `export_manual_struct_to_h` 在遇到 `name=None` 時仍會輸出 `None` 字串，需改成省略名稱【F:src/model/struct_model.py†L267-L283】。
 
 ## TDD 實作步驟
 以下流程每一步皆遵循 **Red → Green → Refactor**：先撰寫或啟用測試，確認失敗後再實作使其通過。
@@ -32,6 +33,7 @@
 ### 4. GUI 與文件
 1. **GUI 測試**：若 GUI 需顯示匿名 bitfield，可在 `tests/test_struct_view.py` 內新增對應顯示測試，先使用 `@unittest.expectedFailure`。
 2. **文件更新**：更新 `STRUCT_PARSING.md` 以及 `README.md` 的功能列表，說明支援匿名 bit field。
+3. **匯出功能**：新增 `test_export_manual_struct_to_h_anonymous_bitfield` 測試，確保 `export_manual_struct_to_h` 省略名稱時輸出正確【F:tests/test_struct_model.py†L961-L973】。
 
 ### 5. 迭代與驗證
 - 每完成一項功能立即執行 `run_all_tests.py`，確保所有既有與新測試皆通過。

--- a/src/model/struct_model.py
+++ b/src/model/struct_model.py
@@ -272,12 +272,18 @@ class StructModel:
         lines = [f"struct {struct_name} {{"]
         for m in members:
             type_name = m.get("type", "")
-            name = m.get("name", "")
+            name = m.get("name")
             bit_size = m.get("bit_size", 0)
             if bit_size > 0:
-                lines.append(f"    {type_name} {name} : {bit_size};")
+                if name:
+                    lines.append(f"    {type_name} {name} : {bit_size};")
+                else:
+                    lines.append(f"    {type_name} : {bit_size};")
             else:
-                lines.append(f"    {type_name} {name};")
+                if name:
+                    lines.append(f"    {type_name} {name};")
+                else:
+                    lines.append(f"    {type_name};")
         lines.append("};")
         lines.append(f"// total size: {total_size} bytes")
         return "\n".join(lines)

--- a/tests/test_struct_model.py
+++ b/tests/test_struct_model.py
@@ -958,6 +958,20 @@ class TestStructModel(unittest.TestCase):
         self.assertIn("unsigned int b : 5;", h_content)
         self.assertIn("// total size: 1 bytes", h_content)
 
+    def test_export_manual_struct_to_h_anonymous_bitfield(self):
+        members = [
+            {"name": "a", "type": "unsigned int", "bit_size": 3},
+            {"name": None, "type": "unsigned int", "bit_size": 5},
+            {"name": "b", "type": "unsigned int", "bit_size": 4},
+        ]
+        total_size = 2
+        self.model.set_manual_struct(members, total_size)
+        h_content = self.model.export_manual_struct_to_h()
+        self.assertIn("unsigned int a : 3;", h_content)
+        self.assertIn("unsigned int : 5;", h_content)
+        self.assertNotIn("None :", h_content)
+        self.assertIn("unsigned int b : 4;", h_content)
+
     def test_manual_struct_byte_bit_size_layout(self):
         model = StructModel()
         members = [


### PR DESCRIPTION
## Summary
- handle `name=None` in `export_manual_struct_to_h`
- describe new behaviour and tests in docs
- document anonymous bitfield support in README and STRUCT_PARSING
- test exporting manual structs with anonymous bitfields

## Testing
- `python3 -m pytest tests/test_struct_model.py::TestStructModel::test_export_manual_struct_to_h_anonymous_bitfield -q`
- `python3 run_all_tests.py` *(fails: FileNotFoundError: .venv/bin/python)*

------
https://chatgpt.com/codex/tasks/task_e_68765c39c96483268f3b2c77ee858254