### PR TITLE
Add InputFieldProcessor unit tests

### DIFF
--- a/tests/test_input_field_processor.py
+++ b/tests/test_input_field_processor.py
@@ -68,5 +68,21 @@ class TestInputFieldProcessorXMLDriven(unittest.TestCase):
                     result = self.processor.process_input_field(subcase['input'], subcase['byte_size'], subcase['endianness'])
                     self.assertEqual(result.hex(), subcase['expected'].lower())
 
+    def test_pad_hex_input(self):
+        for case in self.test_data:
+            extra = case.get('extra_tests', {})
+            for subcase in extra.get('pad_hex_input', []):
+                with self.subTest(input=subcase['input'], byte_size=subcase['byte_size']):
+                    result = self.processor.pad_hex_input(subcase['input'], subcase['byte_size'])
+                    self.assertEqual(result, subcase['expected'].lower())
+
+    def test_convert_to_raw_bytes(self):
+        for case in self.test_data:
+            extra = case.get('extra_tests', {})
+            for subcase in extra.get('convert_to_raw_bytes', []):
+                with self.subTest(padded_hex=subcase['padded_hex'], byte_size=subcase['byte_size'], endianness=subcase['endianness']):
+                    result = self.processor.convert_to_raw_bytes(subcase['padded_hex'], subcase['byte_size'], subcase['endianness'])
+                    self.assertEqual(result.hex(), subcase['expected'].lower())
+
 if __name__ == '__main__':
     unittest.main() 


### PR DESCRIPTION
## Summary
- extend `InputFieldProcessor` with `pad_hex_input` and `convert_to_raw_bytes`
- add XML-driven tests for new helper methods

## Testing
- `python -m unittest tests.test_input_field_processor -v`

------
https://chatgpt.com/codex/tasks/task_e_6877744123ac832687e9481cf706e11d