### PR TITLE
Update docs for XML-driven tests

### DIFF
--- a/docs/development/v4_test_refactor.md
+++ b/docs/development/v4_test_refactor.md
@@ -35,3 +35,9 @@
     - `test_load_struct_from_file_invalid` (例外處理)
     - `test_is_supported_field_size` (API 邊界)
     - `test_struct_view.py` 中的 UI 事件觸發測試 (GUI 行為)
+
+## 4. 進度紀錄
+
+- `test_input_field_processor.py` 已全面使用 `test_input_field_processor_config.xml`，其中 `pad_hex_input` 與 `convert_to_raw_bytes` 測試皆改為 XML 驅動。
+- `test_struct_model_integration.py` 的多數案例現已由 `test_struct_model_integration_config.xml` 載入。
+- 仍維持 hardcode 的僅剩行為與例外處理相關測試，例如上列三項。

--- a/tests/README.md
+++ b/tests/README.md
@@ -31,6 +31,8 @@ Tests for the input conversion mechanism.
 Tests for the InputFieldProcessor module.
 - Tests hex input padding functionality
 - Tests raw byte conversion with endianness
+- `pad_hex_input` cases are XML-driven
+- `convert_to_raw_bytes` cases are XML-driven
 - Tests complete input processing pipeline
 - Tests error handling and edge cases
 - Tests supported field size validation
@@ -46,7 +48,7 @@ Tests for struct parsing and layout calculation.
 - Tests bitfield layout calculation
 
 ### `test_struct_model_integration.py` *(新增)*
-Tests for StructModel integration functionality.
+Tests for StructModel integration functionality. Most cases are loaded from `tests/data/test_struct_model_integration_config.xml`.
 - Tests StructModel initialization and state management
 - Tests struct loading from files
 - Tests hex data parsing with various scenarios


### PR DESCRIPTION
## Summary
- document XML-driven `pad_hex_input` and `convert_to_raw_bytes`
- note that `test_struct_model_integration.py` uses XML cases
- add progress notes about completed test migrations

## Testing
- `python3 -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68777467fe388326835387f3229da62f