### PR TITLE
Refactor StructModel integration tests to XML-driven data

### DIFF
--- a/tests/data/test_struct_model_integration_config.xml
+++ b/tests/data/test_struct_model_integration_config.xml
@@ -1,0 +1,124 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<struct_model_integration_tests>
+    <test_case name="load_struct_valid" description="Load struct from file">
+        <struct_definition><![CDATA[
+            struct TestStruct {
+                char a;
+                int b;
+                long long c;
+            };
+        ]]></struct_definition>
+        <expected_total_size>16</expected_total_size>
+        <expected_struct_align>8</expected_struct_align>
+        <expected_layout_len>4</expected_layout_len>
+    </test_case>
+    <test_case name="load_struct_invalid" description="Invalid struct raises error">
+        <struct_definition><![CDATA[This is not a struct definition]]></struct_definition>
+        <expected_exception>ValueError</expected_exception>
+    </test_case>
+    <test_case name="parse_hex_simple" description="Parse simple hex data" endianness="little">
+        <struct_definition><![CDATA[
+            struct SimpleStruct {
+                char a;
+                int b;
+            };
+        ]]></struct_definition>
+        <input_data><hex>1200000001000000</hex></input_data>
+        <expected_results>
+            <member name="a" value="18" hex_raw="12"/>
+            <member name="(padding)" value="-" hex_raw="000000"/>
+            <member name="b" value="1" hex_raw="01000000"/>
+        </expected_results>
+    </test_case>
+    <test_case name="parse_hex_big_endian" description="Parse big endian data" endianness="big">
+        <struct_definition><![CDATA[
+            struct EndianStruct {
+                char a;
+                int b;
+            };
+        ]]></struct_definition>
+        <input_data><hex>12345678</hex></input_data>
+        <expected_results>
+            <member name="a" value="0" hex_raw="00"/>
+            <member name="(padding)" value="-" hex_raw="000000"/>
+            <member name="b" value="305419896" hex_raw="12345678"/>
+        </expected_results>
+    </test_case>
+    <test_case name="parse_hex_bitfields" description="Parse bitfield struct" endianness="little">
+        <struct_definition><![CDATA[
+            struct BitFieldStruct {
+                int a : 1;
+                int b : 2;
+                char c;
+            };
+        ]]></struct_definition>
+        <input_data><hex>07000000ff000000</hex></input_data>
+        <expected_results>
+            <member name="a" value="1" hex_raw="07000000"/>
+            <member name="b" value="3" hex_raw="07000000"/>
+            <member name="c" value="255" hex_raw="ff"/>
+            <member name="(final padding)" value="-" hex_raw="000000"/>
+        </expected_results>
+    </test_case>
+    <test_case name="parse_hex_bool_true" description="Parse boolean true" endianness="little">
+        <struct_definition><![CDATA[
+            struct BoolStruct {
+                bool flag;
+            };
+        ]]></struct_definition>
+        <input_data><hex>01</hex></input_data>
+        <expected_results>
+            <member name="flag" value="True" hex_raw="01"/>
+        </expected_results>
+    </test_case>
+    <test_case name="parse_hex_bool_false" description="Parse boolean false" endianness="little">
+        <struct_definition><![CDATA[
+            struct BoolStruct {
+                bool flag;
+            };
+        ]]></struct_definition>
+        <input_data><hex>00</hex></input_data>
+        <expected_results>
+            <member name="flag" value="False" hex_raw="00"/>
+        </expected_results>
+    </test_case>
+    <test_case name="parse_hex_pointer" description="Parse pointer value" endianness="little">
+        <struct_definition><![CDATA[
+            struct PointerStruct {
+                int* ptr;
+            };
+        ]]></struct_definition>
+        <input_data><hex>123456789ABCDEF0</hex></input_data>
+        <expected_results>
+            <member name="ptr" value="17356517385562371090" hex_raw="123456789abcdef0"/>
+        </expected_results>
+    </test_case>
+    <test_case name="parse_hex_padding" description="Parse with padding" endianness="little">
+        <struct_definition><![CDATA[
+            struct PaddingStruct {
+                char a;
+                int b;
+            };
+        ]]></struct_definition>
+        <input_data><hex>12345678</hex></input_data>
+        <expected_results>
+            <member name="a" value="0" hex_raw="00"/>
+            <member name="(padding)" value="-" hex_raw="000000"/>
+            <member name="b" value="2018915346" hex_raw="12345678"/>
+        </expected_results>
+    </test_case>
+    <test_case name="parse_hex_short_input" description="Parse short hex input padded" endianness="little">
+        <struct_definition><![CDATA[
+            struct ShortStruct {
+                int a;
+                long long b;
+            };
+        ]]></struct_definition>
+        <input_data><hex>12000000000000003400000000000000</hex></input_data>
+        <expected_results>
+            <member name="a" value="18" hex_raw="12000000"/>
+            <member name="(padding)" value="-" hex_raw="00000000"/>
+            <member name="b" value="52" hex_raw="3400000000000000"/>
+        </expected_results>
+    </test_case>
+</struct_model_integration_tests>

--- a/tests/test_struct_model_integration.py
+++ b/tests/test_struct_model_integration.py
@@ -7,290 +7,28 @@ import sys
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
 
 from model.struct_model import StructModel
+from tests.xml_struct_model_loader import load_struct_model_tests
+
 
 class TestStructModel(unittest.TestCase):
-    """Test cases for StructModel integration functionality."""
-    
+    """Behaviour tests not covered by data-driven cases."""
+
     def setUp(self):
-        """Set up test fixtures."""
         self.model = StructModel()
-    
+
     def test_init(self):
-        """Test StructModel initialization."""
         self.assertIsNone(self.model.struct_name)
         self.assertEqual(self.model.members, [])
         self.assertEqual(self.model.layout, [])
         self.assertEqual(self.model.total_size, 0)
         self.assertEqual(self.model.struct_align, 1)
         self.assertIsNotNone(self.model.input_processor)
-    
-    def test_load_struct_from_file_valid(self):
-        """Test loading a valid struct from file."""
-        # Create temporary file with valid struct
-        content = """
-        struct TestStruct {
-            char a;
-            int b;
-            long long c;
-        };
-        """
-        with tempfile.NamedTemporaryFile(mode='w', delete=False, suffix='.h') as f:
-            f.write(content)
-            file_path = f.name
-        
-        try:
-            struct_name, layout, total_size, struct_align = self.model.load_struct_from_file(file_path)
-            
-            self.assertEqual(struct_name, "TestStruct")
-            self.assertEqual(total_size, 16)  # 1 + 3(padding) + 4 + 8
-            self.assertEqual(struct_align, 8)
-            self.assertEqual(len(layout), 4)  # 3 members + 1 padding
-            
-            # Check that model state is updated
-            self.assertEqual(self.model.struct_name, "TestStruct")
-            self.assertEqual(self.model.total_size, 16)
-            self.assertEqual(self.model.struct_align, 8)
-            
-        finally:
-            os.unlink(file_path)
-    
-    def test_load_struct_from_file_invalid(self):
-        """Test loading an invalid struct from file."""
-        # Create temporary file with invalid content
-        content = "This is not a struct definition"
-        with tempfile.NamedTemporaryFile(mode='w', delete=False, suffix='.h') as f:
-            f.write(content)
-            file_path = f.name
-        
-        try:
-            with self.assertRaises(ValueError):
-                self.model.load_struct_from_file(file_path)
-        finally:
-            os.unlink(file_path)
-    
-    def test_parse_hex_data_simple(self):
-        """Test parsing simple hex data."""
-        # Load a simple struct first
-        content = """
-        struct SimpleStruct {
-            char a;
-            int b;
-        };
-        """
-        with tempfile.NamedTemporaryFile(mode='w', delete=False, suffix='.h') as f:
-            f.write(content)
-            file_path = f.name
-        
-        try:
-            self.model.load_struct_from_file(file_path)
-            
-            # Parse hex data: 1 byte for char, 3 bytes padding, 4 bytes for int
-            hex_data = "12" + "00"*3 + "01000000"  # a=0x12, b=1
-            parsed_values = self.model.parse_hex_data(hex_data, 'little')
-            
-            self.assertEqual(len(parsed_values), 3)  # 2 members + 1 padding
-            
-            # Check char member
-            self.assertEqual(parsed_values[0]["name"], "a")
-            self.assertEqual(parsed_values[0]["value"], "18")  # 0x12 = 18
-            self.assertEqual(parsed_values[0]["hex_raw"], "12")
-            
-            # Check padding
-            self.assertEqual(parsed_values[1]["name"], "(padding)")
-            self.assertEqual(parsed_values[1]["value"], "-")
-            
-            # Check int member
-            self.assertEqual(parsed_values[2]["name"], "b")
-            self.assertEqual(parsed_values[2]["value"], "1")
-            
-        finally:
-            os.unlink(file_path)
-    
-    def test_parse_hex_data_big_endian(self):
-        """Test parsing hex data with big endian byte order."""
-        # Load a struct with multiple fields
-        content = """
-        struct EndianStruct {
-            char a;
-            int b;
-        };
-        """
-        with tempfile.NamedTemporaryFile(mode='w', delete=False, suffix='.h') as f:
-            f.write(content)
-            file_path = f.name
-        
-        try:
-            self.model.load_struct_from_file(file_path)
-            
-            # Parse hex data with big endian
-            hex_data = "12345678"  # 4 bytes for int
-            parsed_values = self.model.parse_hex_data(hex_data, 'big')
-            
-            # Check int member (big endian)
-            int_member = next(item for item in parsed_values if item["name"] == "b")
-            self.assertEqual(int_member["value"], "305419896")  # 0x12345678
-            
-        finally:
-            os.unlink(file_path)
-    
-    def test_parse_hex_data_bitfields(self):
-        """Test parsing hex data for struct with bit fields."""
-        # Load a struct with bit fields
-        content = """
-        struct BitFieldStruct {
-            int a : 1;
-            int b : 2;
-            char c;
-        };
-        """
-        with tempfile.NamedTemporaryFile(mode='w', delete=False, suffix='.h') as f:
-            f.write(content)
-            file_path = f.name
-        try:
-            self.model.load_struct_from_file(file_path)
-            # 動態取得 layout offset/size
-            layout = self.model.layout
-            # 找出 bitfield storage unit offset/size
-            a_layout = next(item for item in layout if item["name"] == "a")
-            c_layout = next(item for item in layout if item["name"] == "c")
-            total_size = self.model.total_size
-            # 準備全 0
-            hex_bytes = bytearray(total_size)
-            # bitfield storage unit: 設定 offset 處 0x07
-            hex_bytes[a_layout["offset"]:a_layout["offset"]+a_layout["size"]] = bytes([0x07] + [0x00]*(a_layout["size"]-1))
-            # char c: 設定 offset 處 0xff
-            hex_bytes[c_layout["offset"]] = 0xff
-            hex_data = hex_bytes.hex()
-            parsed_values = self.model.parse_hex_data(hex_data, 'little')
-            a_member = next(item for item in parsed_values if item["name"] == "a")
-            b_member = next(item for item in parsed_values if item["name"] == "b")
-            c_member = next(item for item in parsed_values if item["name"] == "c")
-            self.assertEqual(a_member["value"], "1")
-            self.assertEqual(b_member["value"], "3")
-            self.assertEqual(c_member["value"], "255")
-        finally:
-            os.unlink(file_path)
-    
-    def test_parse_hex_data_bool(self):
-        """Test parsing boolean values."""
-        # Load a struct with bool field
-        content = """
-        struct BoolStruct {
-            bool flag;
-        };
-        """
-        with tempfile.NamedTemporaryFile(mode='w', delete=False, suffix='.h') as f:
-            f.write(content)
-            file_path = f.name
-        
-        try:
-            self.model.load_struct_from_file(file_path)
-            
-            # Parse hex data
-            parsed_values = self.model.parse_hex_data("01", 'little')
-            self.assertEqual(parsed_values[0]["value"], "True")
-            
-            parsed_values = self.model.parse_hex_data("00", 'little')
-            self.assertEqual(parsed_values[0]["value"], "False")
-            
-        finally:
-            os.unlink(file_path)
-    
-    def test_parse_hex_data_pointer(self):
-        """Test parsing pointer values."""
-        # Load a struct with pointer field
-        content = """
-        struct PointerStruct {
-            int* ptr;
-        };
-        """
-        with tempfile.NamedTemporaryFile(mode='w', delete=False, suffix='.h') as f:
-            f.write(content)
-            file_path = f.name
-        
-        try:
-            self.model.load_struct_from_file(file_path)
-            
-            # Parse hex data
-            hex_data = "123456789ABCDEF0"  # 8 bytes for pointer
-            parsed_values = self.model.parse_hex_data(hex_data, 'little')
-            
-            self.assertEqual(parsed_values[0]["name"], "ptr")
-            # Pointer value should be parsed as integer
-            self.assertIsInstance(int(parsed_values[0]["value"]), int)
-            
-        finally:
-            os.unlink(file_path)
-    
-    def test_parse_hex_data_padding(self):
-        """Test parsing hex data with padding."""
-        # Load a struct with padding
-        content = """
-        struct PaddingStruct {
-            char a;
-            int b;
-        };
-        """
-        with tempfile.NamedTemporaryFile(mode='w', delete=False, suffix='.h') as f:
-            f.write(content)
-            file_path = f.name
-        
-        try:
-            self.model.load_struct_from_file(file_path)
-            
-            # Parse hex data
-            hex_data = "12345678"  # 4 bytes
-            parsed_values = self.model.parse_hex_data(hex_data, 'little')
-            
-            # Should have padding entry
-            padding_entries = [item for item in parsed_values if item["name"] == "(padding)"]
-            self.assertGreater(len(padding_entries), 0)
-            
-            for padding in padding_entries:
-                self.assertEqual(padding["value"], "-")
-                self.assertIsInstance(padding["hex_raw"], str)
-            
-        finally:
-            os.unlink(file_path)
-    
-    def test_parse_hex_data_short_input(self):
-        """Test parsing hex data that's shorter than expected (should pad with zeros)."""
-        # Load a struct
-        content = """
-        struct ShortStruct {
-            int a;
-            long long b;
-        };
-        """
-        with tempfile.NamedTemporaryFile(mode='w', delete=False, suffix='.h') as f:
-            f.write(content)
-            file_path = f.name
-        try:
-            self.model.load_struct_from_file(file_path)
-            layout = self.model.layout
-            a_layout = next(item for item in layout if item["name"] == "a")
-            b_layout = next(item for item in layout if item["name"] == "b")
-            total_size = self.model.total_size
-            hex_bytes = bytearray(total_size)
-            # int a: 設定 offset 處 0x12
-            hex_bytes[a_layout["offset"]] = 0x12
-            # long long b: 設定 offset 處 0x34
-            hex_bytes[b_layout["offset"]] = 0x34
-            hex_data = hex_bytes.hex()
-            parsed_values = self.model.parse_hex_data(hex_data, 'little')
-            int_member = next(item for item in parsed_values if item["name"] == "a")
-            self.assertEqual(int_member["value"], str(0x12))
-        finally:
-            os.unlink(file_path)
-    
+
     def test_parse_hex_data_no_layout(self):
-        """Test parsing hex data without loading struct layout first."""
         with self.assertRaises(ValueError):
             self.model.parse_hex_data("1234", 'little')
-    
+
     def test_hex_raw_formatting_and_padding(self):
-        """Test that hex_raw is zero-padded and can be safely prefixed with 0x for display."""
-        # Load a simple struct
         content = """
         struct HexStruct {
             char a;
@@ -300,32 +38,65 @@ class TestStructModel(unittest.TestCase):
         with tempfile.NamedTemporaryFile(mode='w', delete=False, suffix='.h') as f:
             f.write(content)
             file_path = f.name
-        
         try:
             self.model.load_struct_from_file(file_path)
-            
-            # Parse hex data
-            hex_data = "12"
-            parsed_values = self.model.parse_hex_data(hex_data, 'little')
-            
-            # Check hex_raw formatting
+            parsed_values = self.model.parse_hex_data("12", 'little')
             for item in parsed_values:
                 if item["name"] != "(padding)":
                     hex_raw = item["hex_raw"]
-                    # Should be even length (each byte = 2 hex chars)
                     self.assertEqual(len(hex_raw) % 2, 0)
-                    # Should be valid hex
-                    int(hex_raw, 16)  # Should not raise ValueError
-                    # Should be zero-padded to correct size
-                    # Find the corresponding layout item to get size
-                    layout_item = next((layout_item for layout_item in self.model.layout if layout_item["name"] == item["name"]), None)
+                    int(hex_raw, 16)
+                    layout_item = next((l for l in self.model.layout if l["name"] == item["name"]), None)
                     if layout_item:
                         expected_size = layout_item["size"] * 2
                         self.assertEqual(len(hex_raw), expected_size)
-            
         finally:
             os.unlink(file_path)
 
 
+class TestStructModelIntegrationXMLDriven(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        config_file = os.path.join(
+            os.path.dirname(__file__),
+            'data',
+            'test_struct_model_integration_config.xml',
+        )
+        cls.cases = load_struct_model_tests(config_file)
+
+    def test_integration_cases(self):
+        for case in self.cases:
+            with self.subTest(name=case['name']):
+                model = StructModel()
+                with tempfile.NamedTemporaryFile(mode='w', delete=False, suffix='.h') as f:
+                    f.write(case['struct_definition'])
+                    file_path = f.name
+                try:
+                    if 'expected_exception' in case:
+                        with self.assertRaises(eval(case['expected_exception'])):
+                            model.load_struct_from_file(file_path)
+                        continue
+                    struct_name, layout, total_size, struct_align = model.load_struct_from_file(file_path)
+                    if 'expected_total_size' in case:
+                        self.assertEqual(total_size, case['expected_total_size'])
+                    if 'expected_struct_align' in case:
+                        self.assertEqual(struct_align, case['expected_struct_align'])
+                    if 'expected_layout_len' in case:
+                        self.assertEqual(len(layout), case['expected_layout_len'])
+
+                    if case.get('input_hex'):
+                        endian = case.get('endianness', 'little')
+                        result = model.parse_hex_data(case['input_hex'], endian)
+                        for expect in case['expected']:
+                            found = next((item for item in result if item['name'] == expect['name']), None)
+                            self.assertIsNotNone(found, f"Field {expect['name']} not found")
+                            if 'value' in expect:
+                                self.assertEqual(str(found['value']), str(expect['value']))
+                            if 'hex_raw' in expect:
+                                self.assertEqual(found['hex_raw'], expect['hex_raw'])
+                finally:
+                    os.unlink(file_path)
+
+
 if __name__ == '__main__':
-    unittest.main() 
+    unittest.main()

--- a/tests/xml_struct_model_loader.py
+++ b/tests/xml_struct_model_loader.py
@@ -15,8 +15,21 @@ class StructModelXMLTestLoader(BaseXMLTestLoader):
         return data
 
     def parse_extra(self, case):
-        # 若未來有特殊欄位可在此擴充，目前無特殊欄位
-        return {}
+        extra = {}
+        # optional numeric expectations
+        ets = case.find('expected_total_size')
+        if ets is not None and ets.text:
+            extra['expected_total_size'] = int(ets.text.strip())
+        esa = case.find('expected_struct_align')
+        if esa is not None and esa.text:
+            extra['expected_struct_align'] = int(esa.text.strip())
+        ell = case.find('expected_layout_len')
+        if ell is not None and ell.text:
+            extra['expected_layout_len'] = int(ell.text.strip())
+        exc = case.find('expected_exception')
+        if exc is not None and exc.text:
+            extra['expected_exception'] = exc.text.strip()
+        return extra
 
 def load_struct_model_tests(xml_path):
     return StructModelXMLTestLoader(xml_path).cases 


### PR DESCRIPTION
## Summary
- add `test_struct_model_integration_config.xml` covering various integration scenarios
- update loader to parse new fields for integration expectations
- rewrite `test_struct_model_integration.py` to drive most tests from XML
- keep behaviour tests that cannot be data-driven

## Testing
- `python -m unittest tests.test_struct_model_integration -v`

------
https://chatgpt.com/codex/tasks/task_e_6877745184788326aac09e429c710007