### PR TITLE
Add XML-driven tests for struct parser

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -125,6 +125,16 @@ Tests for GUI view functionality with TDD approach.
   - Tests validation state display
   - Tests edge cases (empty struct, full struct, partial fill)
 
+### `test_struct_parser_v2.py`
+Tests for `parse_member_line_v2` and related helpers.
+- Cases are loaded from `tests/data/test_struct_parser_v2_config.xml`
+- Loader: `tests.xml_struct_parser_v2_loader`
+
+### `test_struct_parser_utils.py`
+Utility tests for parser helper functions.
+- Cases are loaded from `tests/data/test_struct_parser_utils_config.xml`
+- Loader: `tests.xml_struct_parser_utils_loader`
+
 ### `test_config_parser.py`
 
 **DEPRECATED**: 此檔案已被 XML loader 標準化方案取代，未來可安全移除。

--- a/tests/data/test_struct_parser_utils_config.xml
+++ b/tests/data/test_struct_parser_utils_config.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<struct_parser_utils_tests>
+    <parse_member_line_cases>
+        <case name="regular_member">
+            <line>int value</line>
+            <expected return_type="tuple" type="int" name="value"/>
+        </case>
+        <case name="pointer_member">
+            <line>char* ptr</line>
+            <expected return_type="tuple" type="pointer" name="ptr"/>
+        </case>
+        <case name="bitfield_member">
+            <line>int flag : 3</line>
+            <expected return_type="dict" type="int" name="flag" is_bitfield="true" bit_size="3"/>
+        </case>
+        <case name="anonymous_bitfield_member" xfail="true">
+            <line>int : 3</line>
+            <expected return_type="dict" type="int" name="" is_bitfield="true" bit_size="3"/>
+        </case>
+        <case name="array_member_dims">
+            <line>short data[4][2]</line>
+            <expected return_type="dict" type="short" name="data" array_dims="4,2"/>
+        </case>
+    </parse_member_line_cases>
+    <extract_struct_body_cases>
+        <case name="simple_body_extraction">
+            <content><![CDATA[
+        struct Simple {
+            int a;
+            char b;
+        };
+            ]]></content>
+            <expected_name>Simple</expected_name>
+            <expected_contains>
+                <line>int a;</line>
+                <line>char b;</line>
+            </expected_contains>
+        </case>
+    </extract_struct_body_cases>
+</struct_parser_utils_tests>

--- a/tests/data/test_struct_parser_v2_config.xml
+++ b/tests/data/test_struct_parser_v2_config.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<struct_parser_v2_tests>
+    <test_case name="regular_member">
+        <line>int value</line>
+        <expected type="int" name="value" is_bitfield="false"/>
+    </test_case>
+    <test_case name="pointer_member">
+        <line>char* ptr</line>
+        <expected type="pointer" name="ptr" is_bitfield="false"/>
+    </test_case>
+    <test_case name="bitfield_member">
+        <line>unsigned int flag : 3</line>
+        <expected type="unsigned int" name="flag" is_bitfield="true" bit_size="3"/>
+    </test_case>
+</struct_parser_v2_tests>

--- a/tests/test_struct_parser_v2.py
+++ b/tests/test_struct_parser_v2.py
@@ -15,29 +15,26 @@ from model.struct_parser import (
     StructDef,
 )
 from model.layout import LayoutCalculator
+from tests.xml_struct_parser_v2_loader import load_struct_parser_v2_tests
 
 class TestParseMemberLineV2(unittest.TestCase):
-    def test_regular_member(self):
-        m = parse_member_line_v2('int value')
-        self.assertIsInstance(m, MemberDef)
-        self.assertEqual(m.type, 'int')
-        self.assertEqual(m.name, 'value')
-        self.assertFalse(m.is_bitfield)
-        self.assertEqual(m.array_dims, [])
-        self.assertIsNone(m.nested)
+    @classmethod
+    def setUpClass(cls):
+        config_path = os.path.join(os.path.dirname(__file__), 'data',
+                                   'test_struct_parser_v2_config.xml')
+        cls.cases = load_struct_parser_v2_tests(config_path)
 
-    def test_pointer_member(self):
-        m = parse_member_line_v2('char* ptr')
-        self.assertEqual(m.type, 'pointer')
-        self.assertEqual(m.name, 'ptr')
-        self.assertFalse(m.is_bitfield)
-
-    def test_bitfield_member(self):
-        m = parse_member_line_v2('unsigned int flag : 3')
-        self.assertTrue(m.is_bitfield)
-        self.assertEqual(m.type, 'unsigned int')
-        self.assertEqual(m.name, 'flag')
-        self.assertEqual(m.bit_size, 3)
+    def test_member_cases(self):
+        for case in self.cases:
+            with self.subTest(name=case['name']):
+                m = parse_member_line_v2(case['line'])
+                self.assertIsInstance(m, MemberDef)
+                self.assertEqual(m.type, case['expected']['type'])
+                self.assertEqual(m.name, case['expected']['name'])
+                if 'is_bitfield' in case['expected']:
+                    self.assertEqual(m.is_bitfield, case['expected']['is_bitfield'])
+                if 'bit_size' in case['expected']:
+                    self.assertEqual(m.bit_size, case['expected']['bit_size'])
 
 class TestParseStructDefinitionV2(unittest.TestCase):
     def test_simple_struct(self):

--- a/tests/xml_struct_parser_utils_loader.py
+++ b/tests/xml_struct_parser_utils_loader.py
@@ -1,0 +1,57 @@
+import xml.etree.ElementTree as ET
+
+class StructParserUtilsXMLTestLoader:
+    def __init__(self, xml_path):
+        self.tree = ET.parse(xml_path)
+        self.root = self.tree.getroot()
+        self.member_cases = self._parse_member_cases()
+        self.body_cases = self._parse_body_cases()
+
+    def _parse_member_cases(self):
+        cases = []
+        member_section = self.root.find('parse_member_line_cases')
+        if member_section is not None:
+            for case in member_section.findall('case'):
+                line = case.find('line').text.strip()
+                expected_elem = case.find('expected')
+                expected = dict(expected_elem.attrib)
+                return_type = expected.pop('return_type', 'tuple')
+                if 'is_bitfield' in expected:
+                    expected['is_bitfield'] = expected['is_bitfield'] == 'true'
+                if 'bit_size' in expected:
+                    expected['bit_size'] = int(expected['bit_size'])
+                if 'array_dims' in expected:
+                    expected['array_dims'] = [int(x) for x in expected['array_dims'].split(',') if x.strip()]
+                cases.append({
+                    'name': case.get('name', ''),
+                    'line': line,
+                    'expected': expected,
+                    'return_type': return_type,
+                    'xfail': case.get('xfail', 'false') == 'true'
+                })
+        return cases
+
+    def _parse_body_cases(self):
+        cases = []
+        body_section = self.root.find('extract_struct_body_cases')
+        if body_section is not None:
+            for case in body_section.findall('case'):
+                content = case.find('content').text
+                expected_name = case.find('expected_name').text.strip()
+                expected_lines = []
+                ec = case.find('expected_contains')
+                if ec is not None:
+                    for line in ec.findall('line'):
+                        if line.text:
+                            expected_lines.append(line.text.strip())
+                cases.append({
+                    'name': case.get('name', ''),
+                    'content': content,
+                    'expected_name': expected_name,
+                    'expected_contains': expected_lines
+                })
+        return cases
+
+def load_struct_parser_utils_tests(xml_path):
+    loader = StructParserUtilsXMLTestLoader(xml_path)
+    return loader.member_cases, loader.body_cases

--- a/tests/xml_struct_parser_v2_loader.py
+++ b/tests/xml_struct_parser_v2_loader.py
@@ -1,0 +1,30 @@
+import xml.etree.ElementTree as ET
+
+class StructParserV2XMLTestLoader:
+    def __init__(self, xml_path):
+        self.tree = ET.parse(xml_path)
+        self.root = self.tree.getroot()
+        self.cases = self._parse_cases()
+
+    def _parse_cases(self):
+        cases = []
+        for case in self.root.findall('test_case'):
+            line = case.find('line').text.strip()
+            expected_elem = case.find('expected')
+            expected = {
+                'type': expected_elem.get('type'),
+                'name': expected_elem.get('name')
+            }
+            if expected_elem.get('is_bitfield'):
+                expected['is_bitfield'] = expected_elem.get('is_bitfield') == 'true'
+            if expected_elem.get('bit_size'):
+                expected['bit_size'] = int(expected_elem.get('bit_size'))
+            cases.append({
+                'name': case.get('name', ''),
+                'line': line,
+                'expected': expected
+            })
+        return cases
+
+def load_struct_parser_v2_tests(xml_path):
+    return StructParserV2XMLTestLoader(xml_path).cases


### PR DESCRIPTION
## Summary
- add XML configs for struct parser v2 and parser utils
- implement loaders to read new XML files
- refactor tests to use loaders and iterate with subTest
- update documentation for new XML-driven tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68777b052c608326bba213cf183d7590