### PR TITLE
Add XML-driven StructModel v3 tests

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -98,6 +98,11 @@ Tests for manual struct definition integration functionality.
 - Tests struct export functionality
 - Tests integration between manual and file-based struct loading
 
+### `test_struct_model_v3.py` *(XML 驅動)*
+Tests for StructModel V3 helper methods. Cases are loaded from `tests/data/test_struct_model_v3_config.xml`.
+- Tests bit usage calculation for different member lists
+- Tests exported header snippets
+
 ### `test_gui_input_validation.py`
 Tests for GUI input validation and length limiting.
 - Tests hex character validation
@@ -337,6 +342,7 @@ python run_tests.py --test test_input_conversion
 ### 測試結果
 - 支援 array 格式的 XML 測試已通過。
 - 你可以自由設計任何 1/4/8 byte、任意格數、任意數值的自動化測試。
+- StructModel V3 測試案例定義在 `tests/data/test_struct_model_v3_config.xml`，可依此格式擴充。
 
 ## Running Tests
 

--- a/tests/data/test_struct_model_v3_config.xml
+++ b/tests/data/test_struct_model_v3_config.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<struct_model_v3_tests>
+    <test_case name="regular_types" description="calculate bits for regular types">
+        <members>
+            <member name="a" type="char" bit_size="0"/>
+            <member name="b" type="int" bit_size="0"/>
+            <member name="c" type="long long" bit_size="0"/>
+        </members>
+        <total_size>16</total_size>
+        <expected_bits>104</expected_bits>
+    </test_case>
+    <test_case name="bitfields" description="calculate bits for bitfield group">
+        <members>
+            <member name="a" type="unsigned int" bit_size="4"/>
+            <member name="b" type="unsigned int" bit_size="8"/>
+            <member name="c" type="int" bit_size="0"/>
+        </members>
+        <total_size>8</total_size>
+        <expected_bits>64</expected_bits>
+    </test_case>
+    <test_case name="export_struct" description="export struct to C code">
+        <members>
+            <member name="user_id" type="unsigned long long" bit_size="0"/>
+            <member name="status" type="unsigned int" bit_size="4"/>
+            <member name="name" type="char" bit_size="0"/>
+        </members>
+        <total_size>16</total_size>
+        <expected_bits>104</expected_bits>
+        <expected_export_contains>
+            <line>struct TestStruct</line>
+            <line>unsigned long long user_id;</line>
+            <line>unsigned int status : 4;</line>
+            <line>char name;</line>
+            <line>// total size: 16 bytes</line>
+        </expected_export_contains>
+    </test_case>
+</struct_model_v3_tests>

--- a/tests/xml_struct_model_v3_loader.py
+++ b/tests/xml_struct_model_v3_loader.py
@@ -1,0 +1,37 @@
+import xml.etree.ElementTree as ET
+from tests.base_xml_test_loader import BaseXMLTestLoader
+
+class StructModelV3XMLTestLoader(BaseXMLTestLoader):
+    def parse_common_fields(self, case):
+        name = case.get('name', '')
+        description = case.get('description', '')
+        members = []
+        members_elem = case.find('members')
+        if members_elem is not None:
+            for m in members_elem.findall('member'):
+                members.append({
+                    'name': m.get('name', ''),
+                    'type': m.get('type', ''),
+                    'bit_size': int(m.get('bit_size', '0')),
+                })
+        total_size_elem = case.find('total_size')
+        total_size = int(total_size_elem.text.strip()) if total_size_elem is not None and total_size_elem.text else None
+        expected_bits_elem = case.find('expected_bits')
+        expected_bits = int(expected_bits_elem.text.strip()) if expected_bits_elem is not None and expected_bits_elem.text else None
+        expected_export_contains = []
+        export_elem = case.find('expected_export_contains')
+        if export_elem is not None:
+            for line in export_elem.findall('line'):
+                if line.text:
+                    expected_export_contains.append(line.text.strip())
+        return {
+            'name': name,
+            'description': description,
+            'members': members,
+            'total_size': total_size,
+            'expected_bits': expected_bits,
+            'expected_export_contains': expected_export_contains,
+        }
+
+def load_struct_model_v3_tests(xml_path):
+    return StructModelV3XMLTestLoader(xml_path).cases


### PR DESCRIPTION
## Summary
- store StructModel v3 scenarios in `test_struct_model_v3_config.xml`
- implement `xml_struct_model_v3_loader.py` for new config
- refactor `test_struct_model_v3.py` to load XML cases
- mention new config in `tests/README.md`

## Testing
- `python -m unittest tests.test_struct_model_v3.TestStructModelV3XMLDriven -v`
- `python -m unittest tests.test_struct_model_v3 -v`
- `python -m unittest discover tests` *(fails: FileNotFoundError due to missing venv and GUI errors)*

------
https://chatgpt.com/codex/tasks/task_e_68777b1a25448326b2da62a34751f86f