### PR TITLE
Document XML-driven tests

### DIFF
--- a/docs/development/v4_data_type_refactor.md
+++ b/docs/development/v4_data_type_refactor.md
@@ -80,8 +80,8 @@
 ## 五、2024/06/XX 進度紀錄：XML 驅動測試全面遷移與 legacy 移除
 
 ### 1. 測試全面 XML 化
-- 所有核心、例外、單元測試（input conversion, field processor, struct parsing）皆已改為 XML 驅動格式。
-- 僅 GUI、static data、mocking 測試維持 hardcoded，並於文件註明原因。
+- 大多數核心與例外測試（input conversion、field processor、struct parsing 等）皆已改為 XML 驅動格式。
+- GUI 及部分輔助/GUI 相關測試仍以程式碼硬寫，並於文件註明原因。
 - 測試 XML schema 統一，所有 loader 皆繼承 BaseXMLTestLoader，便於擴充與維護。
 
 ### 2. Legacy code/data format 移除

--- a/docs/development/v4_test_refactor.md
+++ b/docs/development/v4_test_refactor.md
@@ -39,5 +39,9 @@
 ## 4. 進度紀錄
 
 - `test_input_field_processor.py` 已全面使用 `test_input_field_processor_config.xml`，其中 `pad_hex_input` 與 `convert_to_raw_bytes` 測試皆改為 XML 驅動。
-- `test_struct_model_integration.py` 的多數案例現已由 `test_struct_model_integration_config.xml` 載入。
-- 仍維持 hardcode 的僅剩行為與例外處理相關測試，例如上列三項。
+- `test_input_conversion.py` 的主要案例改由 `test_input_conversion_config.xml` 與 `test_input_conversion_error_config.xml` 提供。
+- `test_struct_parsing_core.py` 完全讀取 `struct_parsing_test_config.xml` 執行。
+- `test_struct_manual_integration.py` 與 `test_manual_struct_v3_integration.py` 共同使用 `manual_struct_test_config.xml`。
+- `test_struct_model_integration.py` 的多數案例亦由 `test_struct_model_integration_config.xml` 載入。
+- `test_struct_model.py` 新增 `TestStructModelXMLDriven` 類別讀取 `test_struct_model_config.xml`，但仍保留大量舊有的手寫測試。
+- 目前仍有多項 hardcode 測試（如 `test_string_parser.py`、`test_struct_parsing.py`、`test_struct_parser_v2.py`、`test_layout_refactor.py`、`test_struct_presenter.py`、`test_union_preparation.py`、各 GUI 測試以及部分 sanity check），主要涵蓋例外處理與 UI 行為。

--- a/tests/README.md
+++ b/tests/README.md
@@ -14,6 +14,7 @@
 Tests for the UI string configuration system.
 - Tests XML string loading functionality
 - Tests string retrieval with fallback handling
+- *Cases embedded directly in the test file (no external XML)*
 
 ### `test_input_conversion.py`
 Tests for the input conversion mechanism.
@@ -26,6 +27,8 @@ Tests for the input conversion mechanism.
 - Tests invalid input handling
 - Tests integration with model parsing
 - **支援 XML array 格式自動化測試**
+- *Main cases loaded from `tests/data/test_input_conversion_config.xml` and
+  `test_input_conversion_error_config.xml`; a few sanity checks remain in-code*
 
 ### `test_input_field_processor.py`
 Tests for the InputFieldProcessor module.
@@ -36,6 +39,8 @@ Tests for the InputFieldProcessor module.
 - Tests complete input processing pipeline
 - Tests error handling and edge cases
 - Tests supported field size validation
+- *Loads cases from `tests/data/test_input_field_processor_config.xml`; the
+  `is_supported_field_size` check remains hard-coded*
 
 ### `test_struct_parsing.py` *(新增)*
 Tests for struct parsing and layout calculation.
@@ -46,6 +51,7 @@ Tests for struct parsing and layout calculation.
 - Tests LayoutCalculator class functionality
 - Tests memory layout calculation with padding
 - Tests bitfield layout calculation
+- *All test data defined in code*
 
 ### `test_struct_model_integration.py` *(新增)*
 Tests for StructModel integration functionality. Most cases are loaded from `tests/data/test_struct_model_integration_config.xml`.
@@ -57,6 +63,7 @@ Tests for StructModel integration functionality. Most cases are loaded from `tes
 - Tests boolean and pointer value parsing
 - Tests padding handling in parsed data
 - Tests short input handling and zero padding
+- *Behavior and error-path tests at the top of the file remain hard-coded*
 
 ### `test_struct_parsing_core.py`
 Tests for core struct parsing functionality without GUI.
@@ -67,6 +74,7 @@ Tests for core struct parsing functionality without GUI.
 - Tests mixed field sizes (char, short, int, long long)
 - Tests empty input handling
 - **支援 XML 配置檔案自動化測試**
+- *All scenarios loaded from `tests/data/struct_parsing_test_config.xml`*
 
 ### `test_struct_model.py` *(大幅擴充)*
 Tests for core struct model functionality with comprehensive coverage.
@@ -89,6 +97,9 @@ Tests for core struct model functionality with comprehensive coverage.
 - **Legacy Compatibility Tests**:
   - Tests length field to bit_size conversion
   - Tests backward compatibility with old data formats
+- *Includes an XML-driven suite (`TestStructModelXMLDriven`) using
+  `tests/data/test_struct_model_config.xml`, while many older unit tests remain
+  hard-coded*
 
 ### `test_struct_manual_integration.py` *(新增)*
 Tests for manual struct definition integration functionality.
@@ -97,6 +108,7 @@ Tests for manual struct definition integration functionality.
 - Tests real-time remaining space calculation
 - Tests struct export functionality
 - Tests integration between manual and file-based struct loading
+- *Cases sourced from `tests/data/manual_struct_test_config.xml`*
 
 ### `test_gui_input_validation.py`
 Tests for GUI input validation and length limiting.


### PR DESCRIPTION
## Summary
- mark XML vs in-code test coverage in `tests/README.md`
- update v4 test refactor notes with latest progress
- clarify wording in data type refactor doc about remaining hard-coded tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68777b1ef35883269573a8c5fb4e0465