### PR TITLE
Move struct model tests to XML

### DIFF
--- a/docs/development/v4_test_refactor.md
+++ b/docs/development/v4_test_refactor.md
@@ -40,4 +40,5 @@
 
 - `test_input_field_processor.py` 已全面使用 `test_input_field_processor_config.xml`，其中 `pad_hex_input` 與 `convert_to_raw_bytes` 測試皆改為 XML 驅動。
 - `test_struct_model_integration.py` 的多數案例現已由 `test_struct_model_integration_config.xml` 載入。
+- `test_struct_model.py` 大多數解析、layout 與複雜範例測試皆改以 XML 描述，配置檔為 `test_struct_model_config.xml`。
 - 仍維持 hardcode 的僅剩行為與例外處理相關測試，例如上列三項。

--- a/tests/README.md
+++ b/tests/README.md
@@ -70,6 +70,7 @@ Tests for core struct parsing functionality without GUI.
 
 ### `test_struct_model.py` *(大幅擴充)*
 Tests for core struct model functionality with comprehensive coverage.
+Most parsing, layout, hex parsing and complex example cases are now loaded from `tests/data/test_struct_model_config.xml`.
 - **Bitfield Support Tests**:
   - Tests bitfield parsing from C++ struct definitions
   - Tests bitfield layout calculation with storage units

--- a/tests/data/test_struct_model_config.xml
+++ b/tests/data/test_struct_model_config.xml
@@ -182,4 +182,175 @@
             <member name="val" value_little="2378182078228332544" value_big="289" hex_raw="0000000000000121"/>
         </expected_results>
     </test_case>
+
+    <test_case name="layout_empty_members" description="Empty struct layout">
+        <struct_definition><![CDATA[
+            struct Empty {
+            };
+        ]]></struct_definition>
+        <expected_total_size>0</expected_total_size>
+        <expected_struct_align>1</expected_struct_align>
+        <expected_layout_len>0</expected_layout_len>
+    </test_case>
+
+    <test_case name="layout_simple_no_padding" description="No padding required">
+        <struct_definition><![CDATA[
+            struct Simple {
+                char a;
+                char b;
+                char c;
+            };
+        ]]></struct_definition>
+        <expected_total_size>3</expected_total_size>
+        <expected_struct_align>1</expected_struct_align>
+        <expected_layout_len>3</expected_layout_len>
+        <expected_results>
+            <member name="a" type="char" size="1" offset="0"/>
+            <member name="b" type="char" size="1" offset="1"/>
+            <member name="c" type="char" size="1" offset="2"/>
+        </expected_results>
+    </test_case>
+
+    <test_case name="layout_with_padding" description="Padding between char and int">
+        <struct_definition><![CDATA[
+            struct Pad {
+                char a;
+                int b;
+            };
+        ]]></struct_definition>
+        <expected_total_size>8</expected_total_size>
+        <expected_struct_align>4</expected_struct_align>
+        <expected_layout_len>3</expected_layout_len>
+        <expected_results>
+            <member name="a" type="char" size="1" offset="0"/>
+            <member name="(padding)" type="padding" size="3" offset="1"/>
+            <member name="b" type="int" size="4" offset="4"/>
+        </expected_results>
+    </test_case>
+
+    <test_case name="layout_final_padding" description="Final padding at end">
+        <struct_definition><![CDATA[
+            struct EndPad {
+                int a;
+                char b;
+            };
+        ]]></struct_definition>
+        <expected_total_size>8</expected_total_size>
+        <expected_struct_align>4</expected_struct_align>
+        <expected_layout_len>3</expected_layout_len>
+        <expected_results>
+            <member name="a" type="int" size="4" offset="0"/>
+            <member name="b" type="char" size="1" offset="4"/>
+            <member name="(final padding)" type="padding" size="3" offset="5"/>
+        </expected_results>
+    </test_case>
+
+    <test_case name="layout_complex_struct" description="Complex layout with multiple paddings">
+        <struct_definition><![CDATA[
+            struct Complex {
+                char a;
+                int b;
+                char c;
+                double d;
+            };
+        ]]></struct_definition>
+        <expected_total_size>24</expected_total_size>
+        <expected_struct_align>8</expected_struct_align>
+        <expected_layout_len>6</expected_layout_len>
+        <expected_results>
+            <member name="a" type="char" size="1" offset="0"/>
+            <member name="(padding)" type="padding" size="3" offset="1"/>
+            <member name="b" type="int" size="4" offset="4"/>
+            <member name="c" type="char" size="1" offset="8"/>
+            <member name="(padding)" type="padding" size="7" offset="9"/>
+            <member name="d" type="double" size="8" offset="16"/>
+        </expected_results>
+    </test_case>
+
+    <test_case name="layout_pointer_alignment" description="Pointer alignment on 64-bit">
+        <struct_definition><![CDATA[
+            struct P {
+                char a;
+                int* ptr;
+            };
+        ]]></struct_definition>
+        <expected_total_size>16</expected_total_size>
+        <expected_struct_align>8</expected_struct_align>
+        <expected_layout_len>3</expected_layout_len>
+        <expected_results>
+            <member name="a" type="char" size="1" offset="0"/>
+            <member name="(padding)" type="padding" size="7" offset="1"/>
+            <member name="ptr" type="pointer" size="8" offset="8"/>
+        </expected_results>
+    </test_case>
+
+    <test_case name="layout_bitfield_packing" description="Bitfield layout packed into single int">
+        <struct_definition><![CDATA[
+            struct BitFields {
+                int a : 1;
+                int b : 2;
+                int c : 5;
+            };
+        ]]></struct_definition>
+        <expected_total_size>4</expected_total_size>
+        <expected_struct_align>4</expected_struct_align>
+        <expected_layout_len>3</expected_layout_len>
+        <expected_results>
+            <member name="a" type="int" size="4" offset="0" is_bitfield="true" bit_offset="0" bit_size="1"/>
+            <member name="b" type="int" size="4" offset="0" is_bitfield="true" bit_offset="1" bit_size="2"/>
+            <member name="c" type="int" size="4" offset="0" is_bitfield="true" bit_offset="3" bit_size="5"/>
+        </expected_results>
+    </test_case>
+
+    <test_case name="layout_padding_fields_info" description="Padding entries carry bitfield fields">
+        <struct_definition><![CDATA[
+            struct PadInfo {
+                char a;
+                int b;
+                char c;
+            };
+        ]]></struct_definition>
+        <expected_total_size>12</expected_total_size>
+        <expected_struct_align>4</expected_struct_align>
+        <expected_layout_len>5</expected_layout_len>
+        <expected_results>
+            <member name="a" type="char" size="1" offset="0" is_bitfield="false" bit_offset="0" bit_size="8"/>
+            <member name="(padding)" type="padding" size="3" offset="1" is_bitfield="false" bit_offset="0" bit_size="24"/>
+            <member name="b" type="int" size="4" offset="4"/>
+            <member name="c" type="char" size="1" offset="8"/>
+            <member name="(final padding)" type="padding" size="3" offset="9" is_bitfield="false" bit_offset="0" bit_size="24"/>
+        </expected_results>
+    </test_case>
+    <test_case name="combined_example_struct" description="Complex struct from example.h">
+        <struct_definition><![CDATA[
+            struct CombinedExample {
+                char      a;
+                int       b;
+                int       c1 : 1;
+                int       c2 : 2;
+                int       c3 : 5;
+                char      d;
+                long long e;
+                unsigned char f;
+                char*     g;
+            };
+        ]]></struct_definition>
+        <expected_total_size>40</expected_total_size>
+        <expected_struct_align>8</expected_struct_align>
+        <expected_layout_len>12</expected_layout_len>
+        <expected_results>
+            <member name="a" type="char" size="1" offset="0"/>
+            <member name="(padding)" type="padding" size="3" offset="1"/>
+            <member name="b" type="int" size="4" offset="4"/>
+            <member name="c1" type="int" size="4" offset="8" is_bitfield="true" bit_offset="0" bit_size="1"/>
+            <member name="c2" type="int" size="4" offset="8" is_bitfield="true" bit_offset="1" bit_size="2"/>
+            <member name="c3" type="int" size="4" offset="8" is_bitfield="true" bit_offset="3" bit_size="5"/>
+            <member name="d" type="char" size="1" offset="12"/>
+            <member name="(padding)" type="padding" size="3" offset="13"/>
+            <member name="e" type="long long" size="8" offset="16"/>
+            <member name="f" type="unsigned char" size="1" offset="24"/>
+            <member name="(padding)" type="padding" size="7" offset="25"/>
+            <member name="g" type="pointer" size="8" offset="32"/>
+        </expected_results>
+    </test_case>
 </struct_model_tests> 

--- a/tests/data/test_struct_parse_definition_config.xml
+++ b/tests/data/test_struct_parse_definition_config.xml
@@ -41,6 +41,19 @@
             <member type="unsigned long" name="value2"/>
         </expected_members>
     </test_case>
+    <test_case name="struct_with_whitespace">
+        <struct_definition><![CDATA[
+            struct WhitespaceStruct {
+                int value1;
+                char value2;
+            };
+        ]]></struct_definition>
+        <expected_struct_name>WhitespaceStruct</expected_struct_name>
+        <expected_members>
+            <member type="int" name="value1"/>
+            <member type="char" name="value2"/>
+        </expected_members>
+    </test_case>
     <test_case name="struct_with_bitfields">
         <struct_definition><![CDATA[
             struct BitFieldStruct {

--- a/tests/xml_struct_model_loader.py
+++ b/tests/xml_struct_model_loader.py
@@ -12,6 +12,14 @@ class StructModelXMLTestLoader(BaseXMLTestLoader):
             if hex_elem is not None and hex_elem.text:
                 input_hex = hex_elem.text.strip()
         data['input_hex'] = input_hex
+        # 對 expected member 轉型
+        numeric_keys = {'offset', 'size', 'bit_size', 'bit_offset'}
+        for entry in data.get('expected', []):
+            for key in list(entry.keys()):
+                if key in numeric_keys:
+                    entry[key] = int(entry[key])
+                elif key == 'is_bitfield':
+                    entry[key] = entry[key].lower() == 'true'
         return data
 
     def parse_extra(self, case):


### PR DESCRIPTION
## Summary
- move CombinedExample struct layout test from Python to XML
- parse/load struct model config file for complex example via loader
- update docs to mention XML-driven complex cases

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68777b1538f48326a059aef843231966