### PR TITLE
XML drive for struct model tests

### DIFF
--- a/docs/development/v4_test_refactor.md
+++ b/docs/development/v4_test_refactor.md
@@ -43,5 +43,5 @@
 - `test_struct_parsing_core.py` 完全讀取 `struct_parsing_test_config.xml` 執行。
 - `test_struct_manual_integration.py` 與 `test_manual_struct_v3_integration.py` 共同使用 `manual_struct_test_config.xml`。
 - `test_struct_model_integration.py` 的多數案例亦由 `test_struct_model_integration_config.xml` 載入。
-- `test_struct_model.py` 新增 `TestStructModelXMLDriven` 類別讀取 `test_struct_model_config.xml`，但仍保留大量舊有的手寫測試。
+ - `test_struct_model.py` 現已大幅精簡，多數解析、layout、hex 相關案例均由 `test_struct_model_config.xml` 載入。
 - 目前仍有多項 hardcode 測試（如 `test_string_parser.py`、`test_struct_parsing.py`、`test_struct_parser_v2.py`、`test_layout_refactor.py`、`test_struct_presenter.py`、`test_union_preparation.py`、各 GUI 測試以及部分 sanity check），主要涵蓋例外處理與 UI 行為。

--- a/tests/README.md
+++ b/tests/README.md
@@ -98,8 +98,8 @@ Tests for core struct model functionality with comprehensive coverage.
   - Tests length field to bit_size conversion
   - Tests backward compatibility with old data formats
 - *Includes an XML-driven suite (`TestStructModelXMLDriven`) using
-  `tests/data/test_struct_model_config.xml`, while many older unit tests remain
-  hard-coded*
+  `tests/data/test_struct_model_config.xml`; only a few behavioral checks
+  remain hard-coded*
 
 ### `test_struct_manual_integration.py` *(新增)*
 Tests for manual struct definition integration functionality.

--- a/tests/data/test_struct_model_config.xml
+++ b/tests/data/test_struct_model_config.xml
@@ -182,4 +182,153 @@
             <member name="val" value_little="2378182078228332544" value_big="289" hex_raw="0000000000000121"/>
         </expected_results>
     </test_case>
+    <test_case name="layout_empty_struct" description="Layout calculation for empty struct">
+        <struct_definition><![CDATA[
+            struct EmptyStruct {
+            };
+        ]]></struct_definition>
+        <expected_total_size>0</expected_total_size>
+        <expected_struct_align>1</expected_struct_align>
+        <expected_layout_len>0</expected_layout_len>
+    </test_case>
+    <test_case name="layout_simple_no_padding" description="Layout calculation with no padding">
+        <struct_definition><![CDATA[
+            struct Simple {
+                char a;
+                char b;
+                char c;
+            };
+        ]]></struct_definition>
+        <expected_total_size>3</expected_total_size>
+        <expected_struct_align>1</expected_struct_align>
+        <expected_layout_len>3</expected_layout_len>
+        <expected_results>
+            <member name="a" type="char" size="1" offset="0"/>
+            <member name="b" type="char" size="1" offset="1"/>
+            <member name="c" type="char" size="1" offset="2"/>
+        </expected_results>
+    </test_case>
+    <test_case name="layout_with_padding" description="Layout calculation with internal padding">
+        <struct_definition><![CDATA[
+            struct PaddingTest {
+                char a;
+                int b;
+            };
+        ]]></struct_definition>
+        <expected_total_size>8</expected_total_size>
+        <expected_struct_align>4</expected_struct_align>
+        <expected_layout_len>3</expected_layout_len>
+        <expected_results>
+            <member name="a" type="char" size="1" offset="0"/>
+            <member name="(padding)" type="padding" size="3" offset="1" bit_offset="0" bit_size="24"/>
+            <member name="b" type="int" size="4" offset="4"/>
+        </expected_results>
+    </test_case>
+    <test_case name="layout_final_padding" description="Layout calculation with final padding">
+        <struct_definition><![CDATA[
+            struct FinalPad {
+                int a;
+                char b;
+            };
+        ]]></struct_definition>
+        <expected_total_size>8</expected_total_size>
+        <expected_struct_align>4</expected_struct_align>
+        <expected_layout_len>3</expected_layout_len>
+        <expected_results>
+            <member name="a" type="int" size="4" offset="0"/>
+            <member name="b" type="char" size="1" offset="4"/>
+            <member name="(final padding)" type="padding" size="3" offset="5" bit_offset="0" bit_size="24"/>
+        </expected_results>
+    </test_case>
+    <test_case name="layout_complex_struct" description="Layout calculation for complex struct">
+        <struct_definition><![CDATA[
+            struct Complex {
+                char a;
+                int b;
+                char c;
+                double d;
+            };
+        ]]></struct_definition>
+        <expected_total_size>24</expected_total_size>
+        <expected_struct_align>8</expected_struct_align>
+        <expected_layout_len>6</expected_layout_len>
+        <expected_results>
+            <member name="a" type="char" size="1" offset="0"/>
+            <member name="(padding)" type="padding" size="3" offset="1" bit_offset="0" bit_size="24"/>
+            <member name="b" type="int" size="4" offset="4"/>
+            <member name="c" type="char" size="1" offset="8"/>
+            <member name="(padding)" type="padding" size="7" offset="9" bit_offset="0" bit_size="56"/>
+            <member name="d" type="double" size="8" offset="16"/>
+        </expected_results>
+    </test_case>
+    <test_case name="layout_pointer_alignment" description="Layout calculation with pointer alignment">
+        <struct_definition><![CDATA[
+            struct PtrStruct {
+                char a;
+                int* ptr;
+            };
+        ]]></struct_definition>
+        <expected_total_size>16</expected_total_size>
+        <expected_struct_align>8</expected_struct_align>
+        <expected_layout_len>3</expected_layout_len>
+        <expected_results>
+            <member name="a" type="char" size="1" offset="0"/>
+            <member name="(padding)" type="padding" size="7" offset="1" bit_offset="0" bit_size="56"/>
+            <member name="ptr" type="pointer" size="8" offset="8"/>
+        </expected_results>
+    </test_case>
+    <test_case name="layout_bitfield" description="Layout calculation for bitfield struct">
+        <struct_definition><![CDATA[
+            struct Bfs {
+                int a : 1;
+                int b : 2;
+                int c : 5;
+            };
+        ]]></struct_definition>
+        <expected_total_size>4</expected_total_size>
+        <expected_struct_align>4</expected_struct_align>
+        <expected_layout_len>3</expected_layout_len>
+        <expected_results>
+            <member name="a" type="int" size="4" offset="0" is_bitfield="true" bit_offset="0" bit_size="1"/>
+            <member name="b" type="int" size="4" offset="0" is_bitfield="true" bit_offset="1" bit_size="2"/>
+            <member name="c" type="int" size="4" offset="0" is_bitfield="true" bit_offset="3" bit_size="5"/>
+        </expected_results>
+    </test_case>
+    <test_case name="layout_padding_layout_fields" description="Padding fields include bit info">
+        <struct_definition><![CDATA[
+            struct PaddingFields {
+                char a;
+                int b;
+                char c;
+            };
+        ]]></struct_definition>
+        <expected_total_size>12</expected_total_size>
+        <expected_struct_align>4</expected_struct_align>
+        <expected_layout_len>5</expected_layout_len>
+        <expected_results>
+            <member name="a" type="char" size="1" offset="0"/>
+            <member name="(padding)" type="padding" size="3" offset="1" bit_offset="0" bit_size="24"/>
+            <member name="b" type="int" size="4" offset="4"/>
+            <member name="c" type="char" size="1" offset="8"/>
+            <member name="(final padding)" type="padding" size="3" offset="9" bit_offset="0" bit_size="24"/>
+        </expected_results>
+    </test_case>
+    <test_case name="hex_raw_formatting" description="Hex raw formatting check" endianness="big">
+        <struct_definition><![CDATA[
+            struct TestStruct {
+                char a;
+                int b;
+                long long c;
+            };
+        ]]></struct_definition>
+        <input_data>
+            <hex>01000000000001230000000004567890</hex>
+        </input_data>
+        <expected_results>
+            <member name="a" hex_raw="01"/>
+            <member name="(padding)" hex_raw="000000"/>
+            <member name="b" hex_raw="00000123"/>
+            <member name="c" hex_raw="0000000004567890"/>
+        </expected_results>
+    </test_case>
 </struct_model_tests> 

--- a/tests/data/test_struct_parse_definition_config.xml
+++ b/tests/data/test_struct_parse_definition_config.xml
@@ -72,4 +72,17 @@
             <member type="int" name="valid_type"/>
         </expected_members>
     </test_case>
-</struct_parse_tests> 
+    <test_case name="struct_with_whitespace">
+        <struct_definition><![CDATA[
+            struct WhitespaceStruct {
+                int value1;
+                char value2;
+            };
+        ]]></struct_definition>
+        <expected_struct_name>WhitespaceStruct</expected_struct_name>
+        <expected_members>
+            <member type="int" name="value1"/>
+            <member type="char" name="value2"/>
+        </expected_members>
+    </test_case>
+</struct_parse_tests>

--- a/tests/test_struct_model.py
+++ b/tests/test_struct_model.py
@@ -26,117 +26,6 @@ from tests.xml_struct_parse_definition_loader import load_struct_parse_definitio
 
 class TestParseStructDefinition(unittest.TestCase):
     """Test cases for parse_struct_definition function."""
-    
-    def test_valid_struct_definition(self):
-        """Test parsing a valid struct definition."""
-        struct_content = """
-        struct TestStruct {
-            int value1;
-            char value2;
-            double value3;
-        };
-        """
-        struct_name, members = parse_struct_definition(struct_content)
-        
-        self.assertEqual(struct_name, "TestStruct")
-        self.assertEqual(len(members), 3)
-        self.assertEqual(members[0], ("int", "value1"))
-        self.assertEqual(members[1], ("char", "value2"))
-        self.assertEqual(members[2], ("double", "value3"))
-    
-    def test_struct_with_pointer(self):
-        """Test parsing struct with pointer types."""
-        struct_content = """
-        struct PointerStruct {
-            int* ptr1;
-            char* ptr2;
-        };
-        """
-        struct_name, members = parse_struct_definition(struct_content)
-        
-        self.assertEqual(struct_name, "PointerStruct")
-        self.assertEqual(len(members), 2)
-        self.assertEqual(members[0], ("pointer", "ptr1"))
-        self.assertEqual(members[1], ("pointer", "ptr2"))
-    
-    def test_struct_with_unsigned_types(self):
-        """Test parsing struct with unsigned types."""
-        struct_content = """
-        struct UnsignedStruct {
-            unsigned int value1;
-            unsigned long value2;
-        };
-        """
-        struct_name, members = parse_struct_definition(struct_content)
-        
-        self.assertEqual(struct_name, "UnsignedStruct")
-        self.assertEqual(len(members), 2)
-        self.assertEqual(members[0], ("unsigned int", "value1"))
-        self.assertEqual(members[1], ("unsigned long", "value2"))
-    
-    def test_struct_with_whitespace(self):
-        """Test parsing struct with various whitespace patterns."""
-        struct_content = """
-        struct WhitespaceStruct {
-            int value1;
-            char value2;
-        };
-        """
-        struct_name, members = parse_struct_definition(struct_content)
-        
-        self.assertEqual(struct_name, "WhitespaceStruct")
-        self.assertEqual(len(members), 2)
-        self.assertEqual(members[0], ("int", "value1"))
-        self.assertEqual(members[1], ("char", "value2"))
-    
-    def test_struct_with_bitfields(self):
-        """Test parsing struct with bit field members."""
-        struct_content = """
-        struct BitFieldStruct {
-            int a : 1;
-            int b : 2;
-            int c : 5;
-        };
-        """
-        struct_name, members = parse_struct_definition(struct_content)
-        self.assertEqual(struct_name, "BitFieldStruct")
-        self.assertEqual(len(members), 3)
-        # Each member should be a dict with type, name, is_bitfield, bit_size
-        self.assertEqual(members[0]["type"], "int")
-        self.assertEqual(members[0]["name"], "a")
-        self.assertTrue(members[0]["is_bitfield"])
-        self.assertEqual(members[0]["bit_size"], 1)
-        self.assertEqual(members[1]["type"], "int")
-        self.assertEqual(members[1]["name"], "b")
-        self.assertTrue(members[1]["is_bitfield"])
-        self.assertEqual(members[1]["bit_size"], 2)
-        self.assertEqual(members[2]["type"], "int")
-        self.assertEqual(members[2]["name"], "c")
-        self.assertTrue(members[2]["is_bitfield"])
-        self.assertEqual(members[2]["bit_size"], 5)
-    
-    def test_invalid_struct_no_match(self):
-        """Test parsing invalid struct that doesn't match pattern."""
-        struct_content = "This is not a struct definition"
-        struct_name, members = parse_struct_definition(struct_content)
-        
-        self.assertIsNone(struct_name)
-        self.assertIsNone(members)
-    
-    def test_struct_with_unknown_type(self):
-        """Test parsing struct with unknown type (should be ignored)."""
-        struct_content = """
-        struct UnknownTypeStruct {
-            int valid_type;
-            unknown_type invalid_type;
-        };
-        """
-        struct_name, members = parse_struct_definition(struct_content)
-        
-        self.assertEqual(struct_name, "UnknownTypeStruct")
-        self.assertEqual(len(members), 1)  # Only valid type should be included
-        self.assertEqual(members[0], ("int", "valid_type"))
-
     @classmethod
     def setUpClass(cls):
         config_file = os.path.join(os.path.dirname(__file__), 'data', 'test_struct_parse_definition_config.xml')
@@ -165,172 +54,6 @@ class TestParseStructDefinition(unittest.TestCase):
                                 self.assertTrue(m.get('is_bitfield', False))
                                 self.assertEqual(m['bit_size'], expect['bit_size'])
 
-
-class TestCalculateLayout(unittest.TestCase):
-    """Test cases for calculate_layout function."""
-    
-    def test_empty_members(self):
-        """Test layout calculation with empty members list."""
-        layout, total_size, max_alignment = calculate_layout([])
-        
-        self.assertEqual(layout, [])
-        self.assertEqual(total_size, 0)
-        self.assertEqual(max_alignment, 1)
-    
-    def test_simple_struct_no_padding(self):
-        """Test layout calculation for struct with no padding needed."""
-        members = [("char", "a"), ("char", "b"), ("char", "c")]
-        layout, total_size, max_alignment = calculate_layout(members)
-        
-        self.assertEqual(len(layout), 3)
-        self.assertEqual(total_size, 3)
-        self.assertEqual(max_alignment, 1)
-        
-        # Check individual member layouts
-        self.assertEqual(layout[0]["name"], "a")
-        self.assertEqual(layout[0]["type"], "char")
-        self.assertEqual(layout[0]["size"], 1)
-        self.assertEqual(layout[0]["offset"], 0)
-        
-        self.assertEqual(layout[1]["name"], "b")
-        self.assertEqual(layout[1]["type"], "char")
-        self.assertEqual(layout[1]["size"], 1)
-        self.assertEqual(layout[1]["offset"], 1)
-        
-        self.assertEqual(layout[2]["name"], "c")
-        self.assertEqual(layout[2]["type"], "char")
-        self.assertEqual(layout[2]["size"], 1)
-        self.assertEqual(layout[2]["offset"], 2)
-    
-    def test_struct_with_padding(self):
-        """Test layout calculation for struct requiring padding."""
-        members = [("char", "a"), ("int", "b")]
-        layout, total_size, max_alignment = calculate_layout(members)
-        
-        self.assertEqual(len(layout), 3)  # char, padding, int
-        self.assertEqual(total_size, 8)
-        self.assertEqual(max_alignment, 4)
-        
-        # Check char member
-        self.assertEqual(layout[0]["name"], "a")
-        self.assertEqual(layout[0]["type"], "char")
-        self.assertEqual(layout[0]["size"], 1)
-        self.assertEqual(layout[0]["offset"], 0)
-        
-        # Check padding
-        self.assertEqual(layout[1]["name"], "(padding)")
-        self.assertEqual(layout[1]["type"], "padding")
-        self.assertEqual(layout[1]["size"], 3)
-        self.assertEqual(layout[1]["offset"], 1)
-        
-        # Check int member
-        self.assertEqual(layout[2]["name"], "b")
-        self.assertEqual(layout[2]["type"], "int")
-        self.assertEqual(layout[2]["size"], 4)
-        self.assertEqual(layout[2]["offset"], 4)
-    
-    def test_struct_with_final_padding(self):
-        """Test layout calculation with final padding."""
-        members = [("int", "a"), ("char", "b")]
-        layout, total_size, max_alignment = calculate_layout(members)
-        
-        self.assertEqual(len(layout), 3)  # int, char, final padding
-        self.assertEqual(total_size, 8)
-        self.assertEqual(max_alignment, 4)
-        
-        # Check int member
-        self.assertEqual(layout[0]["name"], "a")
-        self.assertEqual(layout[0]["type"], "int")
-        self.assertEqual(layout[0]["size"], 4)
-        self.assertEqual(layout[0]["offset"], 0)
-        
-        # Check char member
-        self.assertEqual(layout[1]["name"], "b")
-        self.assertEqual(layout[1]["type"], "char")
-        self.assertEqual(layout[1]["size"], 1)
-        self.assertEqual(layout[1]["offset"], 4)
-        
-        # Check final padding
-        self.assertEqual(layout[2]["name"], "(final padding)")
-        self.assertEqual(layout[2]["type"], "padding")
-        self.assertEqual(layout[2]["size"], 3)
-        self.assertEqual(layout[2]["offset"], 5)
-    
-    def test_complex_struct_layout(self):
-        """Test layout calculation for a complex struct."""
-        members = [
-            ("char", "a"),
-            ("int", "b"),
-            ("char", "c"),
-            ("double", "d")
-        ]
-        layout, total_size, max_alignment = calculate_layout(members)
-        
-        self.assertEqual(len(layout), 6)  # char, padding, int, char, padding, double
-        self.assertEqual(total_size, 24)
-        self.assertEqual(max_alignment, 8)
-        
-        # Verify offsets are correct
-        expected_offsets = [0, 1, 4, 8, 9, 16]
-        for i, expected_offset in enumerate(expected_offsets):
-            self.assertEqual(layout[i]["offset"], expected_offset)
-    
-    def test_pointer_alignment(self):
-        """Test layout calculation with pointer types."""
-        members = [("char", "a"), ("pointer", "ptr")]
-        layout, total_size, max_alignment = calculate_layout(members)
-        
-        self.assertEqual(len(layout), 3)  # char, padding, pointer
-        self.assertEqual(total_size, 16)
-        self.assertEqual(max_alignment, 8)
-        
-        # Check pointer alignment
-        self.assertEqual(layout[2]["type"], "pointer")
-        self.assertEqual(layout[2]["size"], 8)
-        self.assertEqual(layout[2]["offset"], 8)
-
-    def test_bitfield_layout(self):
-        """Test layout calculation for struct with bit fields."""
-        members = [
-            {"type": "int", "name": "a", "is_bitfield": True, "bit_size": 1},
-            {"type": "int", "name": "b", "is_bitfield": True, "bit_size": 2},
-            {"type": "int", "name": "c", "is_bitfield": True, "bit_size": 5},
-        ]
-        layout, total_size, max_alignment = calculate_layout(members)
-        # All bit fields should be packed into a single int (4 bytes)
-        self.assertEqual(len(layout), 3)
-        self.assertEqual(layout[0]["name"], "a")
-        self.assertTrue(layout[0]["is_bitfield"])
-        self.assertEqual(layout[0]["bit_offset"], 0)
-        self.assertEqual(layout[0]["bit_size"], 1)
-        self.assertEqual(layout[1]["name"], "b")
-        self.assertTrue(layout[1]["is_bitfield"])
-        self.assertEqual(layout[1]["bit_offset"], 1)
-        self.assertEqual(layout[1]["bit_size"], 2)
-        self.assertEqual(layout[2]["name"], "c")
-        self.assertTrue(layout[2]["is_bitfield"])
-        self.assertEqual(layout[2]["bit_offset"], 3)
-        self.assertEqual(layout[2]["bit_size"], 5)
-        # All should share the same storage unit (offset 0, size 4)
-        for item in layout:
-            self.assertEqual(item["offset"], 0)
-            self.assertEqual(item["size"], 4)
-        self.assertEqual(total_size, 4)
-        self.assertEqual(max_alignment, 4)
-
-    def test_padding_layout_fields(self):
-        """Test that padding and final padding have correct bitfield-related fields."""
-        members = [("char", "a"), ("int", "b"), ("char", "c")]
-        layout, total_size, max_alignment = calculate_layout(members)
-        # 找出所有 padding 項
-        paddings = [item for item in layout if item["type"] == "padding"]
-        for pad in paddings:
-            self.assertIn("is_bitfield", pad)
-            self.assertIn("bit_offset", pad)
-            self.assertIn("bit_size", pad)
-            self.assertFalse(pad["is_bitfield"])
-            self.assertEqual(pad["bit_offset"], 0)
-            self.assertEqual(pad["bit_size"], pad["size"] * 8)
 
 
 class TestStructModel(unittest.TestCase):
@@ -388,241 +111,6 @@ class TestStructModel(unittest.TestCase):
         
         self.assertIn("No struct layout loaded", str(context.exception))
     
-    def test_parse_hex_data_padding(self):
-        """Test parsing hex data with padding."""
-        struct_content = """
-        struct PaddingStruct {
-            char a;
-            int b;
-        };
-        """
-        
-        with patch("builtins.open", mock_open(read_data=struct_content)):
-            self.model.load_struct_from_file("test_file.h")
-        
-        # Parse hex data
-        hex_data = "41" + "000000" + "02000000"  # char('A') + padding + int(2)
-        result = self.model.parse_hex_data(hex_data, "little")
-        
-        self.assertEqual(len(result), 3)
-        
-        # Check char
-        self.assertEqual(result[0]["name"], "a")
-        self.assertEqual(result[0]["value"], "65")
-        
-        # Check padding
-        self.assertEqual(result[1]["name"], "(padding)")
-        self.assertEqual(result[1]["value"], "-")
-        
-        # Check int
-        self.assertEqual(result[2]["name"], "b")
-        self.assertEqual(result[2]["value"], "2")
-    
-    def test_parse_hex_data_short_input(self):
-        """Test parsing hex data that's shorter than expected (should pad with zeros)."""
-        struct_content = """
-        struct ShortStruct {
-            int value1;
-            int value2;
-        };
-        """
-        
-        with patch("builtins.open", mock_open(read_data=struct_content)):
-            self.model.load_struct_from_file("test_file.h")
-        
-        # Parse hex data that's too short
-        hex_data = "01000000"  # Only 4 bytes instead of 8
-        result = self.model.parse_hex_data(hex_data, "little")
-        self.assertEqual(len(result), 2)
-        self.assertEqual(result[0]["name"], "value1")
-        # 左補零後，hex_data 變成 "0000000001000000"
-        # 第一個 int (4 bytes): 0x00000000 = 0
-        self.assertEqual(result[0]["value"], "0")
-        self.assertEqual(result[1]["name"], "value2")
-        # 第二個 int (4 bytes): 0x01000000 = 16777216
-        self.assertEqual(result[1]["value"], "1")
-    
-    def test_parse_hex_data_big_endian(self):
-        """Test parsing hex data with big endian byte order."""
-        struct_content = """
-        struct EndianStruct {
-            int value1;
-            short value2;
-        };
-        """
-        
-        with patch("builtins.open", mock_open(read_data=struct_content)):
-            self.model.load_struct_from_file("test_file.h")
-        
-        # Parse hex data with big endian
-        hex_data = "00000001" + "0002" + "0000"  # int(1) + short(2) + padding
-        result = self.model.parse_hex_data(hex_data, "big")
-        
-        self.assertEqual(len(result), 3)
-        self.assertEqual(result[0]["name"], "value1")
-        self.assertEqual(result[0]["value"], "1")
-        self.assertEqual(result[1]["name"], "value2")
-        self.assertEqual(result[1]["value"], "2")
-    
-    def test_struct_a_with_8byte_hex_units(self):
-        """Test struct A { char s; long long val; } with 8-byte hex units."""
-        struct_content = """
-        struct A {
-            char s;
-            long long val;
-        };
-        """
-        
-        with patch("builtins.open", mock_open(read_data=struct_content)):
-            self.model.load_struct_from_file("test_file.h")
-        
-        # Input: 8-byte units {1233, 121}
-        # 1233 (8 bytes) + 121 (8 bytes) = 16 bytes total
-        hex_data = "1233000000000000" + "1210000000000000"
-        result = self.model.parse_hex_data(hex_data, "little")
-        
-        self.assertEqual(len(result), 3)  # char, padding, long long
-        
-        # Check char member 's'
-        self.assertEqual(result[0]["name"], "s")
-        self.assertEqual(result[0]["value"], "18")  # 0x12 = 18
-        self.assertEqual(result[0]["hex_raw"], "12")
-        
-        # Check padding (7 bytes after char)
-        self.assertEqual(result[1]["name"], "(padding)")
-        self.assertEqual(result[1]["value"], "-")
-        self.assertEqual(result[1]["hex_raw"], "33000000000000")
-        
-        # Check long long member 'val'
-        self.assertEqual(result[2]["name"], "val")
-        self.assertEqual(result[2]["value"], "4114")  # 0x1210 = 4114
-        self.assertEqual(result[2]["hex_raw"], "1210000000000000")  # little endian: 數值在 little endian 下的 hex 表示
-        
-        # Verify total size is 16 bytes
-        self.assertEqual(self.model.total_size, 16)
-        self.assertEqual(self.model.struct_align, 8)
-
-    def test_struct_a_endian_comparison(self):
-        """Test struct A with both little endian and big endian to show the difference."""
-        struct_content = """
-        struct A {
-            char s;
-            long long val;
-        };
-        """
-        
-        with patch("builtins.open", mock_open(read_data=struct_content)):
-            self.model.load_struct_from_file("test_file.h")
-        
-        # Same hex data: 12330000000000001210000000000000
-        hex_data = "1233000000000000" + "1210000000000000"
-        
-        # Test Little Endian
-        result_little = self.model.parse_hex_data(hex_data, "little")
-        
-        # Test Big Endian
-        result_big = self.model.parse_hex_data(hex_data, "big")
-        
-        print(f"\nLittle Endian vs Big Endian comparison:")
-        print(f"Input hex: {hex_data}")
-        
-        print(f"\nLittle Endian results:")
-        for item in result_little:
-            print(f"  {item['name']}: value={item['value']}, hex_raw={item['hex_raw']}")
-        
-        print(f"\nBig Endian results:")
-        for item in result_big:
-            print(f"  {item['name']}: value={item['value']}, hex_raw={item['hex_raw']}")
-        
-        # Verify the differences
-        # char 's' should be the same in both (single byte)
-        self.assertEqual(result_little[0]["value"], result_big[0]["value"])
-        
-        # long long 'val' should be different
-        self.assertNotEqual(result_little[2]["value"], result_big[2]["value"])
-        
-        # Little endian: 0x1210000000000000 = 4114
-        # Big endian: 0x1210000000000000 = 1301540292310073344
-        self.assertEqual(result_little[2]["value"], "4114")
-        self.assertEqual(result_big[2]["value"], "1301540292310073344")
-
-    def test_struct_a_8byte_field_short_hex(self):
-        """Test 8-byte field with short hex input '121' should be padded to '0000000000000121'."""
-        struct_content = """
-        struct A {
-            long long val;
-        };
-        """
-        with patch("builtins.open", mock_open(read_data=struct_content)):
-            self.model.load_struct_from_file("test_file.h")
-        # 輸入 '121'，應該自動左補零到 8 bytes
-        hex_data = "121"
-        result_little = self.model.parse_hex_data(hex_data, "little")
-        result_big = self.model.parse_hex_data(hex_data, "big")
-        # bytes: 00 00 00 00 00 00 01 21
-        expected_hex_little = "0000000000000121"  # little endian: 數值在 little endian 下的 hex 表示
-        expected_hex_big = "0000000000000121"  # big endian: 直接顯示原始 bytes 的 hex
-        expected_bytes = bytes.fromhex(expected_hex_big)
-        print(f"[DEBUG][hardcode] value_little={result_little[0]['value']} hex_raw={result_little[0]['hex_raw']}")
-        print(f"[DEBUG][hardcode] value_big={result_big[0]['value']} hex_raw={result_big[0]['hex_raw']}")
-        self.assertEqual(result_little[0]["hex_raw"], expected_hex_little)
-        self.assertEqual(result_big[0]["hex_raw"], expected_hex_big)
-        # little endian: int.from_bytes(..., 'little')
-        self.assertEqual(result_little[0]["value"], str(int.from_bytes(expected_bytes, "little")))
-        # big endian: int.from_bytes(..., 'big')
-        self.assertEqual(result_big[0]["value"], str(int.from_bytes(expected_bytes, "big")))
-
-    def test_integration_with_real_file(self):
-        """Integration test using real struct file from tests/data/."""
-        # 使用真實的 struct 檔案進行整合測試
-        test_file_path = os.path.join(os.path.dirname(__file__), "data", "test_struct_a.h")
-        
-        # 確保測試檔案存在
-        self.assertTrue(os.path.exists(test_file_path), f"Test file {test_file_path} does not exist")
-        
-        # 載入 struct
-        struct_name, layout, total_size, struct_align = self.model.load_struct_from_file(test_file_path)
-        
-        # 驗證 struct 資訊
-        self.assertEqual(struct_name, "A")
-        self.assertEqual(len(layout), 3)  # char, padding, long long
-        self.assertEqual(total_size, 16)
-        self.assertEqual(struct_align, 8)
-        
-        # 測試解析 hex 資料
-        hex_data = "121"
-        result = self.model.parse_hex_data(hex_data, "little")
-        
-        # 驗證結果
-        self.assertEqual(len(result), 3)
-        self.assertEqual(result[0]["name"], "s")
-        self.assertEqual(result[2]["name"], "val")
-        
-        # 驗證 hex_raw 是左補零的結果
-        expected_hex_little = "0000000000000121"  # little endian: 數值在 little endian 下的 hex 表示
-        expected_hex_big = "0000000000000121"  # big endian: 直接顯示原始 bytes 的 hex
-        self.assertEqual(result[2]["hex_raw"], expected_hex_little)
-
-    def test_hex_raw_formatting_and_padding(self):
-        """Test that hex_raw is zero-padded and can be safely prefixed with 0x for display."""
-        struct_content = """
-        struct TestStruct {
-            char a;
-            int b;
-            long long c;
-        };
-        """
-        with patch("builtins.open", mock_open(read_data=struct_content)):
-            self.model.load_struct_from_file("test_file.h")
-        # a: 1 byte, padding: 3 bytes, b: 4 bytes, c: 8 bytes
-        # Input: a=0x1, padding=000000, b=0x123, c=0x4567890
-        hex_data = "01" + "000000" + "00000123" + "0000000004567890"
-        result = self.model.parse_hex_data(hex_data, "big")
-        # 檢查 hex_raw 長度與補 0x
-        self.assertEqual(result[0]["hex_raw"], "01")  # 1 byte
-        self.assertEqual(result[1]["hex_raw"], "000000")  # 3 bytes padding
-        self.assertEqual(result[2]["hex_raw"], "00000123")  # 4 bytes
-        self.assertEqual(result[3]["hex_raw"], "0000000004567890")  # 8 bytes
 
     def test_set_manual_struct_sets_members_and_size(self):
         """Test that set_manual_struct correctly sets members and total_size."""
@@ -933,23 +421,43 @@ class TestStructModelXMLDriven(unittest.TestCase):
                 model.struct_name = struct_name
                 model.members = members
                 model.layout, model.total_size, model.struct_align = calculate_layout(members)
-                if case.get('endianness') == 'both':
-                    for endian in ['little', 'big']:
-                        result = model.parse_hex_data(case['input_hex'], endian)
+                if case.get('input_hex'):
+                    if case.get('endianness') == 'both':
+                        for endian in ['little', 'big']:
+                            result = model.parse_hex_data(case['input_hex'], endian)
+                            for expect in case['expected']:
+                                found = next((item for item in result if item['name'] == expect['name']), None)
+                                self.assertIsNotNone(found, f"欄位 {expect['name']} 未找到")
+                                key = f"value_{endian}"
+                                if key in expect:
+                                    self.assertEqual(str(found['value']), str(expect[key]))
+                                if 'hex_raw' in expect:
+                                    self.assertEqual(found.get('hex_raw'), expect['hex_raw'])
+                    else:
+                        result = model.parse_hex_data(case['input_hex'], case.get('endianness', 'little'))
                         for expect in case['expected']:
                             found = next((item for item in result if item['name'] == expect['name']), None)
                             self.assertIsNotNone(found, f"欄位 {expect['name']} 未找到")
-                            key = f"value_{endian}"
-                            if key in expect:
-                                self.assertEqual(str(found['value']), str(expect[key]))
+                            if 'value' in expect:
+                                self.assertEqual(str(found['value']), str(expect['value']))
                             if 'hex_raw' in expect:
                                 self.assertEqual(found.get('hex_raw'), expect['hex_raw'])
                 else:
-                    result = model.parse_hex_data(case['input_hex'], case.get('endianness', 'little'))
-                    for expect in case['expected']:
-                        found = next((item for item in result if item['name'] == expect['name']), None)
-                        self.assertIsNotNone(found, f"欄位 {expect['name']} 未找到")
-                        self.assertEqual(str(found['value']), str(expect['value']))
+                    if 'expected_layout_len' in case:
+                        self.assertEqual(len(model.layout), case['expected_layout_len'])
+                    if 'expected_total_size' in case:
+                        self.assertEqual(model.total_size, case['expected_total_size'])
+                    if 'expected_struct_align' in case:
+                        self.assertEqual(model.struct_align, case['expected_struct_align'])
+                    for i, expect in enumerate(case.get('expected', [])):
+                        item = model.layout[i]
+                        for key, val in expect.items():
+                            if key == 'name':
+                                self.assertEqual(item['name'], val)
+                            elif key == 'type':
+                                self.assertEqual(item['type'], val)
+                            elif key in ('offset', 'size', 'bit_offset', 'bit_size'):
+                                self.assertEqual(item[key], val)
 
 
 if __name__ == "__main__":

--- a/tests/xml_struct_model_loader.py
+++ b/tests/xml_struct_model_loader.py
@@ -12,6 +12,11 @@ class StructModelXMLTestLoader(BaseXMLTestLoader):
             if hex_elem is not None and hex_elem.text:
                 input_hex = hex_elem.text.strip()
         data['input_hex'] = input_hex
+        # 將 expected_results 中的數值欄位轉為 int 方便比對
+        for member in data.get('expected', []):
+            for key in ('offset', 'size', 'bit_offset', 'bit_size'):
+                if key in member:
+                    member[key] = int(member[key])
         return data
 
     def parse_extra(self, case):


### PR DESCRIPTION
## Summary
- migrate layout and hex parsing cases in `test_struct_model.py` to XML
- support numeric layout fields in `xml_struct_model_loader`
- document new XML-driven struct model tests

## Testing
- `python run_tests.py -a` *(fails: Tkinter display errors)*

------
https://chatgpt.com/codex/tasks/task_e_6877856c33d083269daf6ebbc6d5d609