### PR TITLE
XML-driven struct parsing tests

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -51,7 +51,8 @@ Tests for struct parsing and layout calculation.
 - Tests LayoutCalculator class functionality
 - Tests memory layout calculation with padding
 - Tests bitfield layout calculation
-- *All test data defined in code*
+- *Cases loaded from `tests/data/test_struct_parsing_config.xml` using
+  `tests.xml_struct_parsing_loader`*
 
 ### `test_struct_model_integration.py` *(新增)*
 Tests for StructModel integration functionality. Most cases are loaded from `tests/data/test_struct_model_integration_config.xml`.

--- a/tests/data/test_struct_parsing_config.xml
+++ b/tests/data/test_struct_parsing_config.xml
@@ -1,0 +1,187 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<struct_parsing_tests>
+    <!-- Parsing tests -->
+    <test_case name="valid_struct_definition" type="parse">
+        <struct_definition><![CDATA[
+            struct TestStruct {
+                char a;
+                int b;
+                long long c;
+            };
+        ]]></struct_definition>
+        <expected_struct_name>TestStruct</expected_struct_name>
+        <expected_members>
+            <member type="char" name="a" />
+            <member type="int" name="b" />
+            <member type="long long" name="c" />
+        </expected_members>
+    </test_case>
+
+    <test_case name="struct_with_bitfields" type="parse">
+        <struct_definition><![CDATA[
+            struct BitFieldStruct {
+                int a : 1;
+                int b : 2;
+                char c;
+                int d : 3;
+            };
+        ]]></struct_definition>
+        <expected_struct_name>BitFieldStruct</expected_struct_name>
+        <expected_members>
+            <member type="int" name="a" is_bitfield="true" bit_size="1" />
+            <member type="int" name="b" is_bitfield="true" bit_size="2" />
+            <member type="char" name="c" />
+            <member type="int" name="d" is_bitfield="true" bit_size="3" />
+        </expected_members>
+    </test_case>
+
+    <test_case name="struct_with_pointer" type="parse">
+        <struct_definition><![CDATA[
+            struct PointerStruct {
+                int* ptr;
+                char* str;
+            };
+        ]]></struct_definition>
+        <expected_struct_name>PointerStruct</expected_struct_name>
+        <expected_members>
+            <member type="pointer" name="ptr" />
+            <member type="pointer" name="str" />
+        </expected_members>
+    </test_case>
+
+    <test_case name="struct_with_unsigned_types" type="parse">
+        <struct_definition><![CDATA[
+            struct UnsignedStruct {
+                unsigned int a;
+                unsigned long b;
+            };
+        ]]></struct_definition>
+        <expected_struct_name>UnsignedStruct</expected_struct_name>
+        <expected_members>
+            <member type="unsigned int" name="a" />
+            <member type="unsigned long" name="b" />
+        </expected_members>
+    </test_case>
+
+    <test_case name="struct_with_whitespace" type="parse">
+        <struct_definition><![CDATA[
+            struct WhitespaceStruct {
+                char    a;
+                int     b;
+                long long   c;
+            };
+        ]]></struct_definition>
+        <expected_struct_name>WhitespaceStruct</expected_struct_name>
+        <expected_members>
+            <member type="char" name="a" />
+            <member type="int" name="b" />
+            <member type="long long" name="c" />
+        </expected_members>
+    </test_case>
+
+    <test_case name="struct_with_unknown_type" type="parse">
+        <struct_definition><![CDATA[
+            struct UnknownStruct {
+                char a;
+                unknown_type b;
+                int c;
+            };
+        ]]></struct_definition>
+        <expected_struct_name>UnknownStruct</expected_struct_name>
+        <expected_members>
+            <member type="char" name="a" />
+            <member type="int" name="c" />
+        </expected_members>
+    </test_case>
+
+    <test_case name="invalid_struct_no_match" type="parse">
+        <struct_definition>This is not a struct definition</struct_definition>
+        <expect_none />
+    </test_case>
+
+    <!-- Layout calculation tests -->
+    <test_case name="simple_struct_no_padding" type="layout">
+        <struct_definition><![CDATA[
+            struct SimpleStruct {
+                char a;
+                char b;
+                char c;
+            };
+        ]]></struct_definition>
+        <expected_total_size>3</expected_total_size>
+        <expected_alignment>1</expected_alignment>
+        <expected_layout>
+            <entry name="a" offset="0" size="1" />
+            <entry name="b" offset="1" size="1" />
+            <entry name="c" offset="2" size="1" />
+        </expected_layout>
+    </test_case>
+
+    <test_case name="struct_with_padding_layout" type="layout">
+        <struct_definition><![CDATA[
+            struct PaddingStruct {
+                char a;
+                int b;
+                char c;
+            };
+        ]]></struct_definition>
+        <expected_total_size>12</expected_total_size>
+        <expected_alignment>4</expected_alignment>
+        <expected_layout>
+            <entry name="a" offset="0" size="1" />
+            <entry type="padding" size="3" />
+            <entry name="b" offset="4" size="4" />
+            <entry name="c" offset="8" size="1" />
+            <entry type="padding" size="3" />
+        </expected_layout>
+    </test_case>
+
+    <test_case name="bitfield_layout" type="layout">
+        <struct_definition><![CDATA[
+            struct BitFieldStruct {
+                int a : 1;
+                int b : 2;
+                char c;
+                int d : 3;
+            };
+        ]]></struct_definition>
+        <expected_total_size>12</expected_total_size>
+        <expected_alignment>4</expected_alignment>
+        <expected_layout>
+            <entry name="a" offset="0" size="4" bit_offset="0" bit_size="1" />
+            <entry name="b" offset="0" size="4" bit_offset="1" bit_size="2" />
+            <entry name="c" offset="4" size="1" />
+            <entry type="padding" size="3" />
+            <entry name="d" offset="8" size="4" bit_offset="0" bit_size="3" />
+        </expected_layout>
+    </test_case>
+
+    <test_case name="array_member_single_element_layout" type="layout">
+        <struct_definition><![CDATA[
+            struct ArrayStruct {
+                int arr[3][2];
+            };
+        ]]></struct_definition>
+        <expected_total_size>4</expected_total_size>
+        <expected_alignment>4</expected_alignment>
+        <expected_layout>
+            <entry name="arr" offset="0" size="4" />
+        </expected_layout>
+    </test_case>
+
+    <test_case name="layout_item_dataclass" type="layout">
+        <struct_definition><![CDATA[
+            struct DataClassStruct {
+                char a;
+                int b;
+            };
+        ]]></struct_definition>
+        <expected_total_size>8</expected_total_size>
+        <expected_alignment>4</expected_alignment>
+        <expected_layout>
+            <entry name="a" offset="0" size="1" />
+            <entry type="padding" size="3" />
+            <entry name="b" offset="4" size="4" />
+        </expected_layout>
+    </test_case>
+</struct_parsing_tests>

--- a/tests/test_struct_parsing.py
+++ b/tests/test_struct_parsing.py
@@ -1,231 +1,63 @@
 import unittest
-import tempfile
 import os
 import sys
 
-# Add src directory to Python path
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
 
 from model.struct_model import parse_struct_definition, calculate_layout
-from model.layout import LayoutCalculator, LayoutItem
-
-class TestParseStructDefinition(unittest.TestCase):
-    """Test cases for struct definition parsing functionality."""
-    
-    def test_valid_struct_definition(self):
-        """Test parsing a valid struct definition."""
-        content = """
-        struct TestStruct {
-            char a;
-            int b;
-            long long c;
-        };
-        """
-        struct_name, members = parse_struct_definition(content)
-        self.assertEqual(struct_name, "TestStruct")
-        self.assertEqual(len(members), 3)
-        self.assertEqual(members[0], ("char", "a"))
-        self.assertEqual(members[1], ("int", "b"))
-        self.assertEqual(members[2], ("long long", "c"))
-    
-    def test_struct_with_bitfields(self):
-        """Test parsing struct with bit field members."""
-        content = """
-        struct BitFieldStruct {
-            int a : 1;
-            int b : 2;
-            char c;
-            int d : 3;
-        };
-        """
-        struct_name, members = parse_struct_definition(content)
-        self.assertEqual(struct_name, "BitFieldStruct")
-        self.assertEqual(len(members), 4)
-        
-        # Check bitfield members
-        self.assertTrue(members[0]["is_bitfield"])
-        self.assertEqual(members[0]["name"], "a")
-        self.assertEqual(members[0]["bit_size"], 1)
-        
-        self.assertTrue(members[1]["is_bitfield"])
-        self.assertEqual(members[1]["name"], "b")
-        self.assertEqual(members[1]["bit_size"], 2)
-        
-        # Check regular member
-        self.assertEqual(members[2], ("char", "c"))
-        
-        # Check another bitfield
-        self.assertTrue(members[3]["is_bitfield"])
-        self.assertEqual(members[3]["name"], "d")
-        self.assertEqual(members[3]["bit_size"], 3)
-    
-    def test_struct_with_pointer(self):
-        """Test parsing struct with pointer types."""
-        content = """
-        struct PointerStruct {
-            int* ptr;
-            char* str;
-        };
-        """
-        struct_name, members = parse_struct_definition(content)
-        self.assertEqual(struct_name, "PointerStruct")
-        self.assertEqual(len(members), 2)
-        self.assertEqual(members[0], ("pointer", "ptr"))
-        self.assertEqual(members[1], ("pointer", "str"))
-    
-    def test_struct_with_unsigned_types(self):
-        """Test parsing struct with unsigned types."""
-        content = """
-        struct UnsignedStruct {
-            unsigned int a;
-            unsigned long b;
-        };
-        """
-        struct_name, members = parse_struct_definition(content)
-        self.assertEqual(struct_name, "UnsignedStruct")
-        self.assertEqual(len(members), 2)
-        self.assertEqual(members[0], ("unsigned int", "a"))
-        self.assertEqual(members[1], ("unsigned long", "b"))
-    
-    def test_struct_with_whitespace(self):
-        """Test parsing struct with various whitespace patterns."""
-        content = """
-        struct WhitespaceStruct {
-            char    a;
-            int     b;
-            long long   c;
-        };
-        """
-        struct_name, members = parse_struct_definition(content)
-        self.assertEqual(struct_name, "WhitespaceStruct")
-        self.assertEqual(len(members), 3)
-        self.assertEqual(members[0], ("char", "a"))
-        self.assertEqual(members[1], ("int", "b"))
-        self.assertEqual(members[2], ("long long", "c"))
-    
-    def test_struct_with_unknown_type(self):
-        """Test parsing struct with unknown type (should be ignored)."""
-        content = """
-        struct UnknownStruct {
-            char a;
-            unknown_type b;
-            int c;
-        };
-        """
-        struct_name, members = parse_struct_definition(content)
-        self.assertEqual(struct_name, "UnknownStruct")
-        self.assertEqual(len(members), 2)  # unknown_type should be ignored
-        self.assertEqual(members[0], ("char", "a"))
-        self.assertEqual(members[1], ("int", "c"))
-    
-    def test_invalid_struct_no_match(self):
-        """Test parsing invalid struct that doesn't match pattern."""
-        content = "This is not a struct definition"
-        struct_name, members = parse_struct_definition(content)
-        self.assertIsNone(struct_name)
-        self.assertIsNone(members)
+from model.layout import LayoutItem
+from tests.xml_struct_parsing_loader import load_struct_parsing_tests
 
 
-class TestLayoutCalculator(unittest.TestCase):
-    """Test cases for LayoutCalculator class."""
-    
-    def setUp(self):
-        """Set up test fixtures."""
-        self.calculator = LayoutCalculator()
-    
-    def test_simple_struct_no_padding(self):
-        """Test layout calculation for struct with no padding needed."""
-        members = [("char", "a"), ("char", "b"), ("char", "c")]
-        layout, total_size, alignment = self.calculator.calculate(members)
-        
-        self.assertEqual(total_size, 3)
-        self.assertEqual(alignment, 1)
-        self.assertEqual(len(layout), 3)
-        
-        # Check each member
-        self.assertEqual(layout[0]["name"], "a")
-        self.assertEqual(layout[0]["offset"], 0)
-        self.assertEqual(layout[0]["size"], 1)
-        
-        self.assertEqual(layout[1]["name"], "b")
-        self.assertEqual(layout[1]["offset"], 1)
-        self.assertEqual(layout[1]["size"], 1)
-        
-        self.assertEqual(layout[2]["name"], "c")
-        self.assertEqual(layout[2]["offset"], 2)
-        self.assertEqual(layout[2]["size"], 1)
-    
-    def test_struct_with_padding(self):
-        """Test layout calculation for struct requiring padding."""
-        members = [("char", "a"), ("int", "b"), ("char", "c")]
-        layout, total_size, alignment = self.calculator.calculate(members)
-        
-        self.assertEqual(total_size, 12)  # 1 + 3(padding) + 4 + 1 + 3(padding)
-        self.assertEqual(alignment, 4)
-        self.assertEqual(len(layout), 5)  # 3 members + 2 padding entries
-        
-        # Check padding
-        self.assertEqual(layout[1]["type"], "padding")
-        self.assertEqual(layout[1]["size"], 3)
-        self.assertEqual(layout[4]["type"], "padding")
-        self.assertEqual(layout[4]["size"], 3)
-    
-    def test_bitfield_layout(self):
-        """Test layout calculation for struct with bit fields."""
-        members = [
-            {"type": "int", "name": "a", "is_bitfield": True, "bit_size": 1},
-            {"type": "int", "name": "b", "is_bitfield": True, "bit_size": 2},
-            {"type": "char", "name": "c", "is_bitfield": False},
-            {"type": "int", "name": "d", "is_bitfield": True, "bit_size": 3}
-        ]
-        layout, total_size, alignment = self.calculator.calculate(members)
-        
-        self.assertEqual(total_size, 12)  # 4 + 1 + 3(padding) + 4
-        self.assertEqual(alignment, 4)
-        self.assertEqual(len(layout), 5)  # 4 members + 1 padding
-        
-        # 只檢查 is_bitfield 存在的欄位
-        bitfields = [item for item in layout if item.get("is_bitfield")]
-        self.assertEqual(len(bitfields), 3)
-        self.assertEqual(bitfields[0]["bit_offset"], 0)
-        self.assertEqual(bitfields[0]["bit_size"], 1)
-        self.assertEqual(bitfields[1]["bit_offset"], 1)
-        self.assertEqual(bitfields[1]["bit_size"], 2)
-        self.assertEqual(bitfields[2]["bit_offset"], 0)
-        self.assertEqual(bitfields[2]["bit_size"], 3)
-        # 也檢查非 bitfield 欄位
-        non_bf = [item for item in layout if not item.get("is_bitfield") and item["type"] != "padding"]
-        self.assertEqual(len(non_bf), 1)
-        self.assertEqual(non_bf[0]["name"], "c")
+class TestStructParsing(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        xml_path = os.path.join(os.path.dirname(__file__), 'data', 'test_struct_parsing_config.xml')
+        cls.cases = load_struct_parsing_tests(xml_path)
 
-class TestLayoutItemDataclass(unittest.TestCase):
-    """Ensure calculate_layout returns LayoutItem objects."""
-
-    def test_layout_item_instances(self):
-        members = [("char", "a"), ("int", "b")]
-        layout, _, _ = calculate_layout(members)
-        self.assertTrue(all(isinstance(item, LayoutItem) for item in layout))
-        self.assertEqual(layout[0].name, "a")
-        b_entry = next((item for item in layout if item.name == "b"), None)
-        self.assertIsNotNone(b_entry)
-        self.assertEqual(b_entry.type, "int")
-
-
-class TestArrayMemberStubBehavior(unittest.TestCase):
-    """Ensure array members are currently treated as single elements."""
-
-    def test_array_member_single_element_layout(self):
-        calc = LayoutCalculator()
-        members = [{"type": "int", "name": "arr", "array_dims": [3, 2]}]
-        layout, total_size, alignment = calc.calculate(members)
-
-        self.assertEqual(total_size, 4)
-        self.assertEqual(alignment, 4)
-        self.assertEqual(len(layout), 1)
-        self.assertEqual(layout[0].name, "arr")
-        self.assertEqual(layout[0].size, 4)
-
+    def test_struct_parsing_cases(self):
+        for case in self.cases:
+            with self.subTest(case=case['name']):
+                if case['type'] == 'parse':
+                    struct_name, members = parse_struct_definition(case['struct_definition'])
+                    if case.get('expect_none'):
+                        self.assertIsNone(struct_name)
+                        self.assertIsNone(members)
+                        continue
+                    self.assertEqual(struct_name, case['expected_struct_name'])
+                    self.assertEqual(len(members), len(case['expected_members']))
+                    for m, exp in zip(members, case['expected_members']):
+                        if isinstance(m, tuple):
+                            self.assertEqual(m, (exp['type'], exp['name']))
+                        else:
+                            self.assertEqual(m['type'], exp['type'])
+                            self.assertEqual(m['name'], exp['name'])
+                            if exp.get('is_bitfield'):
+                                self.assertTrue(m.get('is_bitfield'))
+                                self.assertEqual(m['bit_size'], exp['bit_size'])
+                else:  # layout tests
+                    _, members = parse_struct_definition(case['struct_definition'])
+                    layout, total_size, align = calculate_layout(members)
+                    self.assertEqual(total_size, case['expected_total_size'])
+                    self.assertEqual(align, case['expected_alignment'])
+                    self.assertEqual(len(layout), len(case['expected_layout']))
+                    for item, exp in zip(layout, case['expected_layout']):
+                        if exp.get('type') == 'padding':
+                            self.assertEqual(item['type'], 'padding')
+                            self.assertEqual(item['size'], exp['size'])
+                        else:
+                            # LayoutItem object expected
+                            self.assertIsInstance(item, LayoutItem)
+                            self.assertEqual(item.name, exp['name'])
+                            self.assertEqual(item.offset, exp['offset'])
+                            self.assertEqual(item.size, exp['size'])
+                            if 'bit_offset' in exp:
+                                self.assertEqual(item.bit_offset, exp['bit_offset'])
+                            if 'bit_size' in exp:
+                                self.assertEqual(item.bit_size, exp['bit_size'])
+                    if case['name'] == 'layout_item_dataclass':
+                        self.assertTrue(all(isinstance(i, LayoutItem) for i in layout))
 
 
 if __name__ == '__main__':
-    unittest.main() 
+    unittest.main()

--- a/tests/xml_struct_parsing_loader.py
+++ b/tests/xml_struct_parsing_loader.py
@@ -1,0 +1,62 @@
+from tests.base_xml_test_loader import BaseXMLTestLoader
+
+class StructParsingXMLTestLoader(BaseXMLTestLoader):
+    """Load struct parsing and layout test cases from XML."""
+
+    def parse_cases(self):
+        cases = []
+        for case in self.root.findall('test_case'):
+            data = {
+                'name': case.get('name', ''),
+                'type': case.get('type', 'parse'),
+                'struct_definition': self._get_text_or_none(case.find('struct_definition')),
+                'expect_none': case.find('expect_none') is not None,
+                'expected_struct_name': self._get_text_or_none(case.find('expected_struct_name')),
+            }
+            # expected members for parsing
+            members = []
+            members_elem = case.find('expected_members')
+            if members_elem is not None:
+                for m in members_elem.findall('member'):
+                    member = {
+                        'type': m.get('type'),
+                        'name': m.get('name'),
+                    }
+                    if m.get('is_bitfield'):
+                        member['is_bitfield'] = m.get('is_bitfield') == 'true'
+                    if m.get('bit_size'):
+                        member['bit_size'] = int(m.get('bit_size'))
+                    if m.get('array_dims'):
+                        member['array_dims'] = [int(x) for x in m.get('array_dims').split(',') if x.strip()]
+                    members.append(member)
+            data['expected_members'] = members
+
+            # layout expectations
+            ets = case.find('expected_total_size')
+            if ets is not None and ets.text:
+                data['expected_total_size'] = int(ets.text.strip())
+            ea = case.find('expected_alignment')
+            if ea is not None and ea.text:
+                data['expected_alignment'] = int(ea.text.strip())
+            layout_elem = case.find('expected_layout')
+            layout = []
+            if layout_elem is not None:
+                for e in layout_elem.findall('entry'):
+                    entry = {
+                        'name': e.get('name'),
+                        'type': e.get('type'),
+                        'offset': int(e.get('offset', 0)),
+                        'size': int(e.get('size', 0)),
+                    }
+                    if e.get('bit_offset'):
+                        entry['bit_offset'] = int(e.get('bit_offset'))
+                    if e.get('bit_size'):
+                        entry['bit_size'] = int(e.get('bit_size'))
+                    layout.append(entry)
+            data['expected_layout'] = layout
+
+            cases.append(data)
+        return cases
+
+def load_struct_parsing_tests(xml_path):
+    return StructParsingXMLTestLoader(xml_path).cases


### PR DESCRIPTION
## Summary
- add `test_struct_parsing_config.xml` defining struct parsing and layout cases
- implement `xml_struct_parsing_loader` to load the XML
- refactor `test_struct_parsing.py` to use XML loader
- document the new loader in `tests/README.md`

## Testing
- `python3 -m unittest tests.test_struct_parsing -v`
- `python3 -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_6877855520288326b97fe466d716b19f