### PR TITLE
Update PyInstaller specs

### DIFF
--- a/packing/CppStructParser-macos.spec
+++ b/packing/CppStructParser-macos.spec
@@ -4,13 +4,10 @@ block_cipher = None
 
 a = Analysis(
     ['../src/main.py'],
-    pathex=[],
+    pathex=['../src'],
     binaries=[],
     datas=[
-        ('../src/config', 'config'),  # 整個 config 目錄
-        ('../src/model', 'model'),    # model 目錄
-        ('../src/view', 'view'),      # view 目錄
-        ('../src/presenter', 'presenter'),  # presenter 目錄
+        ('../src', 'src'),                 # include package root
         ('../examples/example.h', 'examples'),
     ],
     hiddenimports=[

--- a/packing/CppStructParser-windows.spec
+++ b/packing/CppStructParser-windows.spec
@@ -4,13 +4,10 @@ block_cipher = None
 
 a = Analysis(
     ['../src/main.py'],
-    pathex=[],
+    pathex=['../src'],
     binaries=[],
     datas=[
-        ('../src/config', 'config'),  # 整個 config 目錄
-        ('../src/model', 'model'),    # model 目錄
-        ('../src/view', 'view'),      # view 目錄
-        ('../src/presenter', 'presenter'),  # presenter 目錄
+        ('../src', 'src'),                 # include package root
         ('../examples/example.h', 'examples'),
     ],
     hiddenimports=[

--- a/src/main.py
+++ b/src/main.py
@@ -1,9 +1,9 @@
 import os
 import sys
 if getattr(sys, 'frozen', False):
-    # 加入 src 目錄和 exe 目錄
-    sys.path.append(os.path.join(os.path.dirname(sys.executable), 'src'))
-    sys.path.append(os.path.dirname(sys.executable))
+    # 加入 src 目錄和 exe 目錄，確保在前端先被尋找
+    sys.path.insert(0, os.path.join(os.path.dirname(sys.executable), 'src'))
+    sys.path.insert(0, os.path.dirname(sys.executable))
 else:
     # 加入 src 目錄和專案根目錄
     sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '')))


### PR DESCRIPTION
## Summary
- copy entire src directory in Mac/Windows spec files
- ensure src is added before zipped modules when running from a frozen executable

## Testing
- `python run_tests.py --all` *(fails: no display for Tkinter)*

------
https://chatgpt.com/codex/tasks/task_e_687869a255808326bf2670fda65b00af