### PR TITLE
Fix test import paths

### DIFF
--- a/tests/integration/test_struct_model_integration.py
+++ b/tests/integration/test_struct_model_integration.py
@@ -4,7 +4,7 @@ import os
 import sys
 
 # Add src directory to Python path
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..', 'src'))
 
 from src.model.struct_model import StructModel
 from tests.data_driven.xml_struct_model_loader import load_struct_model_tests

--- a/tests/model/test_input_conversion.py
+++ b/tests/model/test_input_conversion.py
@@ -1,6 +1,6 @@
 import sys
 import os
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..', 'src'))
 
 import unittest
 import tempfile

--- a/tests/model/test_input_field_processor.py
+++ b/tests/model/test_input_field_processor.py
@@ -3,7 +3,7 @@ import sys
 import os
 
 # Add src directory to Python path
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..', 'src'))
 
 from src.model.input_field_processor import InputFieldProcessor
 from tests.data_driven.xml_input_field_processor_loader import load_input_field_processor_tests, load_input_field_processor_error_tests

--- a/tests/model/test_struct_model.py
+++ b/tests/model/test_struct_model.py
@@ -12,7 +12,7 @@ import sys
 from unittest.mock import patch, mock_open
 
 # Add src to path to import the model
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..', 'src'))
 
 from src.model.struct_model import (
     parse_struct_definition, 

--- a/tests/model/test_struct_model_v3.py
+++ b/tests/model/test_struct_model_v3.py
@@ -3,7 +3,7 @@ import sys
 import os
 
 # 添加專案根目錄到 Python 路徑
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..', 'src'))
 
 from src.model.struct_model import StructModel
 from tests.data_driven.xml_struct_model_v3_loader import load_struct_model_v3_tests

--- a/tests/model/test_struct_parser_v2.py
+++ b/tests/model/test_struct_parser_v2.py
@@ -4,7 +4,7 @@ import os
 
 # Add project root to Python path
 project_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-sys.path.insert(0, os.path.join(project_root, 'src'))
+sys.path.insert(0, os.path.join(project_root, '..', 'src'))
 sys.path.insert(0, project_root)
 
 from src.model.struct_parser import (

--- a/tests/model/test_struct_parsing.py
+++ b/tests/model/test_struct_parsing.py
@@ -2,7 +2,7 @@ import unittest
 import os
 import sys
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..', 'src'))
 
 from src.model.struct_model import parse_struct_definition, calculate_layout
 from src.model.layout import LayoutItem

--- a/tests/model/test_struct_parsing_core.py
+++ b/tests/model/test_struct_parsing_core.py
@@ -4,7 +4,7 @@ import os
 import xml.etree.ElementTree as ET
 
 # Add src directory to Python path
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..', 'src'))
 
 from src.model.struct_model import StructModel
 from src.model.input_field_processor import InputFieldProcessor

--- a/tests/utils/test_layout_refactor.py
+++ b/tests/utils/test_layout_refactor.py
@@ -3,7 +3,7 @@ import sys
 import unittest
 
 # Add src to path to import the model
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..', 'src'))
 
 from src.model.layout import BaseLayoutCalculator, StructLayoutCalculator, LayoutCalculator
 

--- a/tests/utils/test_pack_alignment_placeholder.py
+++ b/tests/utils/test_pack_alignment_placeholder.py
@@ -2,7 +2,7 @@ import unittest
 import os
 import sys
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..', 'src'))
 
 from src.model.layout import LayoutCalculator
 

--- a/tests/view/test_struct_view_padding.py
+++ b/tests/view/test_struct_view_padding.py
@@ -9,7 +9,7 @@ pytestmark = pytest.mark.skipif(
 )
 
 # 添加專案根目錄到 Python 路徑
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..', 'src'))
 
 from src.view.struct_view import StructView
 from src.presenter.struct_presenter import StructPresenter


### PR DESCRIPTION
## Summary
- fix incorrect relative paths in test modules

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687876cdc04c8326bd23c546e420a023