### PR TITLE
Fix packaging spec to include src package

### DIFF
--- a/packing/CppStructParser-macos.spec
+++ b/packing/CppStructParser-macos.spec
@@ -1,7 +1,6 @@
 # -*- mode: python ; coding: utf-8 -*-
 
 import os
-from PyInstaller.utils.hooks import Tree
 
 block_cipher = None
 
@@ -10,7 +9,10 @@ a = Analysis(
     pathex=[os.path.abspath('..'), os.path.abspath('../src')],
     binaries=[],
     datas=[
-        Tree('../src', prefix='src'),  # include entire src directory
+        ('../src/config', 'config'),  # 整個 config 目錄
+        ('../src/model', 'model'),    # model 目錄
+        ('../src/view', 'view'),      # view 目錄
+        ('../src/presenter', 'presenter'),  # presenter 目錄
         ('../examples/example.h', 'examples'),
     ],
     hiddenimports=[

--- a/packing/CppStructParser-macos.spec
+++ b/packing/CppStructParser-macos.spec
@@ -9,10 +9,7 @@ a = Analysis(
     pathex=[os.path.abspath('..'), os.path.abspath('../src')],
     binaries=[],
     datas=[
-        ('../src/config', 'config'),  # 整個 config 目錄
-        ('../src/model', 'model'),    # model 目錄
-        ('../src/view', 'view'),      # view 目錄
-        ('../src/presenter', 'presenter'),  # presenter 目錄
+        ('../src', 'src'),  # include entire src package
         ('../examples/example.h', 'examples'),
     ],
     hiddenimports=[

--- a/packing/CppStructParser-macos.spec
+++ b/packing/CppStructParser-macos.spec
@@ -1,6 +1,7 @@
 # -*- mode: python ; coding: utf-8 -*-
 
 import os
+from PyInstaller.utils.hooks import Tree
 
 block_cipher = None
 
@@ -9,7 +10,7 @@ a = Analysis(
     pathex=[os.path.abspath('..'), os.path.abspath('../src')],
     binaries=[],
     datas=[
-        ('../src', 'src'),  # include entire src package
+        Tree('../src', prefix='src'),  # include entire src directory
         ('../examples/example.h', 'examples'),
     ],
     hiddenimports=[

--- a/src/main.py
+++ b/src/main.py
@@ -9,9 +9,9 @@ else:
     sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '')))
     sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
-from model import StructModel
-from view import StructView
-from presenter import StructPresenter
+from src.model import StructModel
+from src.view import StructView
+from src.presenter import StructPresenter
 from src.config import load_ui_strings
 
 


### PR DESCRIPTION
## Summary
- bundle the entire `src` package in macOS pyinstaller spec
- restore previous windows spec to avoid changing the working build

## Testing
- `python run_all_tests.py`

------
https://chatgpt.com/codex/tasks/task_e_6878afc9afec832687462781cdae6de3