### PR TITLE
Implement bitfield flattening and pack-aware layout

### DIFF
--- a/tests/model/test_flattening_strategy.py
+++ b/tests/model/test_flattening_strategy.py
@@ -228,7 +228,6 @@ class TestStructFlatteningStrategy:
         struct_node = self.factory.create_struct_node("Bf")
         bf1 = self.factory.create_bitfield_node("a", "unsigned int", 3)
         bf2 = self.factory.create_bitfield_node("b", "unsigned int", 5)
-        bf2.bit_offset = 3
         struct_node.add_child(bf1)
         struct_node.add_child(bf2)
 


### PR DESCRIPTION
## Summary
- enhance `StructFlatteningStrategy` with bitfield-aware offset logic
- compute bitfield bit offsets automatically
- update tests for new behaviour

## Testing
- `pytest tests/model/test_flattening_strategy.py::TestStructFlatteningStrategy::test_flatten_bitfield -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f7fc6326883269cd6bedad082b37a