### PR TITLE
Support pack alignment in layout calculations

### DIFF
--- a/src/model/flattening_strategy.py
+++ b/src/model/flattening_strategy.py
@@ -231,19 +231,20 @@ class StructFlatteningStrategy(FlatteningStrategy):
         """計算 struct 佈局"""
         total_size = 0
         max_alignment = 1
-        
+
         for child in node.children:
             child_layout = self._calculate_child_layout(child)
             total_size = self._align_offset(total_size, child_layout['alignment'])
             total_size += child_layout['size']
             max_alignment = max(max_alignment, child_layout['alignment'])
-        
-        # 最終對齊
-        total_size = self._align_offset(total_size, max_alignment)
-        
+
+        # 最終對齊，pack_alignment 會影響結構對齊
+        effective_align = self._effective_alignment(max_alignment)
+        total_size = self._align_offset(total_size, effective_align)
+
         return {
             'size': total_size,
-            'alignment': max_alignment,
+            'alignment': effective_align,
             'children': [self._calculate_child_layout(child) for child in node.children]
         }
     
@@ -399,11 +400,12 @@ class UnionFlatteningStrategy(FlatteningStrategy):
             max_size = max(max_size, child_layout['size'])
             max_alignment = max(max_alignment, child_layout['alignment'])
 
-        union_size = self._align_offset(max_size, max_alignment)
+        effective_align = self._effective_alignment(max_alignment)
+        union_size = self._align_offset(max_size, effective_align)
 
         return {
             'size': union_size,
-            'alignment': max_alignment,
+            'alignment': effective_align,
             'children': [self._calculate_child_layout(child) for child in node.children]
         }
     

--- a/tests/model/test_flattening_strategy.py
+++ b/tests/model/test_flattening_strategy.py
@@ -246,7 +246,7 @@ class TestStructFlatteningStrategy:
         layout = packed.calculate_layout(struct_node)
 
         assert layout['size'] == 5
-        assert layout['alignment'] == 4
+        assert layout['alignment'] == 1
 
 
 class TestUnionFlatteningStrategy:


### PR DESCRIPTION
## Summary
- handle `pack_alignment` when computing struct and union layouts
- update unit test for pragma pack behavior

## Testing
- `python3 -m pytest tests/model/test_flattening_strategy.py::TestStructFlatteningStrategy::test_layout_with_pack -q`
- `python3 -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f8e232d248326bf64e76523d05b23