### PR TITLE
Implement array/bitfield strategy tests and align offsets

### DIFF
--- a/src/model/flattening_strategy.py
+++ b/src/model/flattening_strategy.py
@@ -105,11 +105,13 @@ class StructFlatteningStrategy(FlatteningStrategy):
                 if self._bitfield_unit_type is not None:
                     current_offset = self._bitfield_unit_offset + self._bitfield_unit_size
                     self._reset_bitfield_state()
+                layout = self._calculate_child_layout(child)
+                current_offset = self._align_offset(current_offset, layout['alignment'])
                 child_nodes = self._flatten_child(child, prefix, current_offset)
                 if child_nodes:
                     new_offset = child_nodes[-1].offset + child_nodes[-1].size
                 else:
-                    new_offset = current_offset
+                    new_offset = current_offset + layout['size']
             result.extend(child_nodes)
             current_offset = new_offset
 

--- a/tests/model/test_array_bitfield_strategies.py
+++ b/tests/model/test_array_bitfield_strategies.py
@@ -1,6 +1,10 @@
 import pytest
 from src.model.ast_node import ASTNodeFactory
-from src.model.flattening_strategy import ArrayFlatteningStrategy, BitfieldFlatteningStrategy
+from src.model.flattening_strategy import (
+    ArrayFlatteningStrategy,
+    BitfieldFlatteningStrategy,
+    StructFlatteningStrategy,
+)
 
 
 class TestArrayFlatteningStrategy:
@@ -37,4 +41,14 @@ class TestBitfieldFlatteningStrategy:
         layout = strategy.calculate_layout(bf)
         assert layout["size"] == 4
         assert layout["alignment"] == 4
+
+    def test_bitfield_pack_alignment(self):
+        factory = ASTNodeFactory()
+        struct = factory.create_struct_node("Bits")
+        struct.add_child(factory.create_bitfield_node("a", "unsigned int", 3))
+        struct.add_child(factory.create_bitfield_node("b", "unsigned int", 5))
+        strategy = StructFlatteningStrategy(pack_alignment=1)
+        layout = strategy.calculate_layout(struct)
+        assert layout["size"] == 4
+        assert layout["alignment"] == 1
 


### PR DESCRIPTION
## Summary
- add a dedicated bitfield pack-alignment test
- ensure struct flattening aligns member offsets

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687f93add44c8326bdd37982701e402f