### PR TITLE
Support nested union/struct arrays in v7 parser

### DIFF
--- a/src/model/parser.py
+++ b/src/model/parser.py
@@ -46,6 +46,15 @@ class V7StructParser:
         except Exception as e:
             print(f"解析錯誤: {e}")
             return None
+
+    def _extract_array_dims(self, token: str):
+        """回傳變數名稱及陣列維度列表"""
+        m = re.match(r"(\w+)((?:\[\d+\])*)", token)
+        if not m:
+            return token, []
+        name = m.group(1)
+        dims = [int(n) for n in re.findall(r"\[(\d+)\]", m.group(2))]
+        return name, dims
     
     def _parse_members(self, body: str, parent_node: ASTNode):
         """解析結構成員"""
@@ -98,11 +107,16 @@ class V7StructParser:
             # 解析成員
             self._parse_members(struct_body, struct_node)
             
-            # 提取變數名稱
-            var_match = re.search(r'\}\s*(\w+)\s*;', line[body_end:])
+            var_match = re.search(r'\}\s*([^;]+)\s*;', line[body_end:])
             if var_match:
-                struct_node.name = var_match.group(1)
-            
+                token = var_match.group(1).strip()
+                name, dims = self._extract_array_dims(token)
+                struct_node.name = name
+                if dims:
+                    array_node = self.node_factory.create_array_node(name, "struct", dims)
+                    array_node.add_child(struct_node)
+                    return array_node
+
             return struct_node
         else:
             # 有名結構
@@ -124,11 +138,16 @@ class V7StructParser:
             # 解析成員
             self._parse_members(struct_body, struct_node)
             
-            # 提取變數名稱
-            var_match = re.search(r'\}\s*(\w+)\s*;', line[body_end:])
+            var_match = re.search(r'\}\s*([^;]+)\s*;', line[body_end:])
             if var_match:
-                struct_node.name = var_match.group(1)
-            
+                token = var_match.group(1).strip()
+                name, dims = self._extract_array_dims(token)
+                struct_node.name = name
+                if dims:
+                    array_node = self.node_factory.create_array_node(name, "struct", dims)
+                    array_node.add_child(struct_node)
+                    return array_node
+
             return struct_node
     
     def _parse_nested_union(self, line: str) -> Optional[ASTNode]:
@@ -150,11 +169,16 @@ class V7StructParser:
             # 解析成員
             self._parse_members(union_body, union_node)
             
-            # 提取變數名稱
-            var_match = re.search(r'\}\s*(\w+)\s*;', line[body_end:])
+            var_match = re.search(r'\}\s*([^;]+)\s*;', line[body_end:])
             if var_match:
-                union_node.name = var_match.group(1)
-            
+                token = var_match.group(1).strip()
+                name, dims = self._extract_array_dims(token)
+                union_node.name = name
+                if dims:
+                    array_node = self.node_factory.create_array_node(name, "union", dims)
+                    array_node.add_child(union_node)
+                    return array_node
+
             return union_node
         else:
             # 有名聯合
@@ -176,11 +200,16 @@ class V7StructParser:
             # 解析成員
             self._parse_members(union_body, union_node)
             
-            # 提取變數名稱
-            var_match = re.search(r'\}\s*(\w+)\s*;', line[body_end:])
+            var_match = re.search(r'\}\s*([^;]+)\s*;', line[body_end:])
             if var_match:
-                union_node.name = var_match.group(1)
-            
+                token = var_match.group(1).strip()
+                name, dims = self._extract_array_dims(token)
+                union_node.name = name
+                if dims:
+                    array_node = self.node_factory.create_array_node(name, "union", dims)
+                    array_node.add_child(union_node)
+                    return array_node
+
             return union_node
     
     def _parse_array_member(self, line: str) -> Optional[ASTNode]:

--- a/tests/model/test_parser.py
+++ b/tests/model/test_parser.py
@@ -334,4 +334,40 @@ class TestV7StructParser:
         assert result.name == "WhitespaceTest"
         assert len(result.children) == 2
         assert result.children[0].name == "x"
-        assert result.children[1].name == "y" 
+        assert result.children[1].name == "y"
+
+    def test_parse_nested_struct_array(self):
+        """巢狀結構陣列解析"""
+        content = """
+        struct SA {
+            struct { int x; } arr[2][2];
+        };
+        """
+
+        result = self.parser.parse_struct_definition(content)
+
+        assert result is not None
+        arr = result.children[0]
+        assert arr.name == "arr"
+        assert arr.is_array is True
+        assert arr.array_dims == [2, 2]
+        assert arr.children[0].is_struct is True
+        assert arr.children[0].children[0].name == "x"
+
+    def test_parse_nested_union_array(self):
+        """巢狀聯合陣列解析"""
+        content = """
+        struct UA {
+            union { int a; char b; } u[3];
+        };
+        """
+
+        result = self.parser.parse_struct_definition(content)
+
+        assert result is not None
+        u = result.children[0]
+        assert u.name == "u"
+        assert u.is_array is True
+        assert u.array_dims == [3]
+        assert u.children[0].is_union is True
+        assert len(u.children[0].children) == 2

--- a/tests/model/test_struct_ast_refactor.py
+++ b/tests/model/test_struct_ast_refactor.py
@@ -33,7 +33,6 @@ from src.model.struct_parser import parse_struct_definition_ast, MemberDef, Stru
                 ("b", "char")
             ])
         ],
-        # marks=pytest.mark.skip(reason="union not supported in MVP")  # 解除 skip
     ),
 ])
 def test_nested_struct_union_array(src, expect):


### PR DESCRIPTION
## Summary
- extend `V7StructParser` with `_extract_array_dims`
- handle array syntax for anonymous and named nested structs/unions
- remove old skip comment in `test_struct_ast_refactor`
- add parser tests for nested struct/union arrays

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687faf4ffe7c8326856d413ec221d0d2