### PR TITLE
Enable nested struct/union arrays flattening

### DIFF
--- a/src/model/flattening_strategy.py
+++ b/src/model/flattening_strategy.py
@@ -163,26 +163,25 @@ class StructFlatteningStrategy(FlatteningStrategy):
     
     def _flatten_nested(self, node: ASTNode, prefix: str, base_offset: int) -> List[FlattenedNode]:
         """展平巢狀結構節點"""
-        result = []
-        
-        # 修正：匿名結構不應該在名稱中加入結構名稱
+        # 直接遞迴使用對應策略展平，並加上偏移量
+        if node.is_struct:
+            strategy = StructFlatteningStrategy(self.pack_alignment)
+        else:
+            strategy = UnionFlatteningStrategy(self.pack_alignment)
+
         if node.is_anonymous:
-            # 為匿名結構生成一個臨時名稱
             anonymous_name = f"anonymous_{node.id[:8]}"
             nested_prefix = f"{prefix}{anonymous_name}."
         else:
-            # 檢查是否在陣列上下文中（前綴包含陣列索引）
             if '[' in prefix and ']' in prefix:
-                # 在陣列上下文中，結構應該被視為匿名結構
                 nested_prefix = prefix
             else:
                 nested_prefix = f"{prefix}{node.name}."
-        
-        for child in node.children:
-            child_nodes = self._flatten_child(child, nested_prefix, base_offset)
-            result.extend(child_nodes)
-        
-        return result
+
+        nodes = strategy.flatten_node(node, nested_prefix)
+        for n in nodes:
+            n.offset += base_offset
+        return nodes
     
     def _create_flattened_node(self, node: ASTNode, prefix: str, base_offset: int) -> FlattenedNode:
         """建立展平節點"""
@@ -389,26 +388,25 @@ class UnionFlatteningStrategy(FlatteningStrategy):
     
     def _flatten_nested(self, node: ASTNode, prefix: str, base_offset: int) -> List[FlattenedNode]:
         """展平巢狀結構節點"""
-        result = []
-        
-        # 修正：匿名結構不應該在名稱中加入結構名稱
+        # 直接遞迴使用對應策略展平，並加上偏移量
+        if node.is_struct:
+            strategy = StructFlatteningStrategy(self.pack_alignment)
+        else:
+            strategy = UnionFlatteningStrategy(self.pack_alignment)
+
         if node.is_anonymous:
-            # 為匿名結構生成一個臨時名稱
             anonymous_name = f"anonymous_{node.id[:8]}"
             nested_prefix = f"{prefix}{anonymous_name}."
         else:
-            # 檢查是否在陣列上下文中（前綴包含陣列索引）
             if '[' in prefix and ']' in prefix:
-                # 在陣列上下文中，結構應該被視為匿名結構
                 nested_prefix = prefix
             else:
                 nested_prefix = f"{prefix}{node.name}."
-        
-        for child in node.children:
-            child_nodes = self._flatten_child(child, nested_prefix, base_offset)
-            result.extend(child_nodes)
-        
-        return result
+
+        nodes = strategy.flatten_node(node, nested_prefix)
+        for n in nodes:
+            n.offset += base_offset
+        return nodes
     
     def _create_flattened_node(self, node: ASTNode, prefix: str, base_offset: int) -> FlattenedNode:
         """建立展平節點"""

--- a/tests/model/test_flattening_strategy.py
+++ b/tests/model/test_flattening_strategy.py
@@ -170,6 +170,42 @@ class TestStructFlatteningStrategy:
         assert flattened[1].name == "arr[0].y"
         assert flattened[2].name == "arr[1].x"
         assert flattened[3].name == "arr[1].y"
+
+    def test_flatten_union_array(self):
+        """union 陣列展平"""
+        struct_node = self.factory.create_struct_node("UnionArray")
+        union_array = self.factory.create_array_node("u", "union", [2])
+        union = self.factory.create_union_node("InnerU")
+        union.add_child(self.factory.create_basic_node("a", "int"))
+        union.add_child(self.factory.create_basic_node("b", "char"))
+        union_array.add_child(union)
+        struct_node.add_child(union_array)
+
+        flattened = self.strategy.flatten_node(struct_node)
+
+        assert [n.name for n in flattened] == [
+            "u[0].a", "u[0].b", "u[1].a", "u[1].b"
+        ]
+
+    def test_flatten_multi_dim_struct_array(self):
+        """多維結構陣列展平"""
+        struct_node = self.factory.create_struct_node("NDStruct")
+        array_node = self.factory.create_array_node("mat", "struct", [2, 2])
+        inner = self.factory.create_struct_node("S")
+        inner.add_child(self.factory.create_basic_node("x", "int"))
+        inner.add_child(self.factory.create_basic_node("y", "char"))
+        array_node.add_child(inner)
+        struct_node.add_child(array_node)
+
+        flattened = self.strategy.flatten_node(struct_node)
+
+        expected_names = [
+            "mat[0][0].x", "mat[0][0].y",
+            "mat[0][1].x", "mat[0][1].y",
+            "mat[1][0].x", "mat[1][0].y",
+            "mat[1][1].x", "mat[1][1].y",
+        ]
+        assert [n.name for n in flattened] == expected_names
     
     def test_calculate_layout_simple(self):
         """測試簡單佈局計算"""

--- a/tests/model/test_struct_ast_refactor.py
+++ b/tests/model/test_struct_ast_refactor.py
@@ -83,6 +83,16 @@ def test_anonymous_struct_union_flatten(src, expect_names):
         int matrix[2][3];
     };
     """, ["matrix[0][0]", "matrix[1][2]"]),
+    ("""
+    struct S {
+        union { int a; char b; } u_arr[2];
+    };
+    """, ["u_arr[0].a", "u_arr[1].b"]),
+    ("""
+    struct S {
+        struct { int x; } nd[2][2];
+    };
+    """, ["nd[0][0].x", "nd[1][1].x"]),
 ])
 def test_struct_union_nd_array_flatten(src, expect):
     sdef = parse_struct_definition_ast(src)


### PR DESCRIPTION
## Summary
- fix nested struct/union flattening when inside arrays
- support prefix and offset handling via recursive strategy calls
- add tests for union arrays and multi‑dimensional struct arrays
- extend AST parser tests for union arrays

## Testing
- `pytest tests/model/test_flattening_strategy.py::TestStructFlatteningStrategy::test_flatten_multi_dim_struct_array -q`
- `pytest tests/model/test_flattening_strategy.py::TestStructFlatteningStrategy::test_flatten_union_array -q`
- `pytest tests/model/test_struct_ast_refactor.py::test_struct_union_nd_array_flatten -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687fbba9f3c48326808df09dec9f72e6