### PR TITLE
Add union parsing support

### DIFF
--- a/tests/model/test_struct_ast_refactor.py
+++ b/tests/model/test_struct_ast_refactor.py
@@ -137,4 +137,19 @@ def _flatten_member_names(sdef):
 def test_anonymous_bitfield(src, expect):
     sdef = parse_struct_definition_ast(src)
     names = [m.name for m in sdef.members]
-    assert names == expect 
+    assert names == expect
+
+
+def test_union_definition_ast():
+    src = """
+    union U {
+        int a;
+        char b;
+    };
+    """
+    from src.model.struct_parser import parse_union_definition_ast
+
+    udef = parse_union_definition_ast(src)
+    assert isinstance(udef, UnionDef)
+    assert udef.name == "U"
+    assert [m.name for m in udef.members] == ["a", "b"]


### PR DESCRIPTION
## Summary
- support parsing of top-level unions via `parse_union_definition_ast`
- detect union/struct in `parse_c_definition_ast`
- test union parsing in AST refactor tests

## Testing
- `pytest tests/model/test_struct_ast_refactor.py::test_union_definition_ast -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687fc20f5c108326958863c4e576acee