### PR TITLE
docs: mark nested flatten tasks complete

### DIFF
--- a/docs/development/v7_nested_struct_union_array_flatten.md
+++ b/docs/development/v7_nested_struct_union_array_flatten.md
@@ -32,11 +32,11 @@
 - 每次 edge case/功能補齊，需同步更新 XML 測資與文件。
 
 ## 六、目前狀態與 TODO
-- [ ] 巢狀 union/struct/array AST/flatten 已完成/待補齊
-- [ ] 匿名 struct/union/bitfield AST/flatten 已完成/待補齊
-- [ ] N-D array 巢狀展平已完成/待補齊
-- [ ] XML 驅動測試已覆蓋/待補齊
-- [ ] 測試 stub/skip 已解除/待補齊
+- [x] 巢狀 union/struct/array AST/flatten 已完成
+- [x] 匿名 struct/union/bitfield AST/flatten 已完成
+- [x] N-D array 巢狀展平已完成
+- [x] XML 驅動測試已覆蓋
+- [x] 測試 stub/skip 已解除
 
 ---
 


### PR DESCRIPTION
## Summary
- mark nested union/struct/array tasks done in v7 docs

## Testing
- `python run_tests.py` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_687fd37bc3948326aee719684f9ace9c