### PR TITLE
Add V7 Presenter with GUI integration

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -3,4 +3,8 @@
 # using the Model-View-Presenter (MVP) architectural pattern.
 
 __version__ = "1.0.0"
-__author__ = "C++ Struct Parser Team" 
+__author__ = "C++ Struct Parser Team"
+
+from .presenter import StructPresenter, V7Presenter
+
+__all__ = ["StructPresenter", "V7Presenter"]

--- a/src/presenter/__init__.py
+++ b/src/presenter/__init__.py
@@ -2,5 +2,6 @@
 # Contains presentation logic and coordinates between Model and View
 
 from src.presenter.struct_presenter import StructPresenter, HexProcessingError
+from src.presenter.v7_presenter import V7Presenter
 
-__all__ = ['StructPresenter'] 
+__all__ = ['StructPresenter', 'V7Presenter']

--- a/src/presenter/v7_presenter.py
+++ b/src/presenter/v7_presenter.py
@@ -1,0 +1,149 @@
+import time
+from typing import Any, Dict, List, Optional
+
+from src.model.v7_init import (
+    ASTNode,
+    FlattenedNode,
+    V7StructParser,
+    StructFlatteningStrategy,
+    FlatteningStrategy,
+)
+
+
+class V7Presenter:
+    """Simplified presenter for the v7 AST/flattening pipeline."""
+
+    def __init__(self, view=None):
+        self.view = view
+        self.ast_root: Optional[ASTNode] = None
+        self.flattened_nodes: List[FlattenedNode] = []
+        self.parser = V7StructParser()
+        self.flattening_strategy: FlatteningStrategy = self._create_flattening_strategy()
+        self.context: Dict[str, Any] = self._init_context()
+
+    def _init_context(self) -> Dict[str, Any]:
+        return {
+            "display_mode": "tree",
+            "expanded_nodes": ["root"],
+            "selected_node": None,
+            "error": None,
+            "loading": False,
+            "version": "1.0",
+            "extra": {},
+            "last_update_time": time.time(),
+        }
+
+    def _create_flattening_strategy(self) -> FlatteningStrategy:
+        return StructFlatteningStrategy()
+
+    def load_struct_definition(self, content: str) -> bool:
+        try:
+            self.context["loading"] = True
+            self._update_context()
+
+            self.ast_root = self.parser.parse_struct_definition(content)
+            if not self.ast_root:
+                self.context["error"] = "解析失敗"
+                self.context["loading"] = False
+                self._update_context()
+                return False
+
+            self.flattened_nodes = self.flattening_strategy.flatten_node(self.ast_root)
+            self.context["loading"] = False
+            self.context["error"] = None
+            self.context["last_update_time"] = time.time()
+            self._update_context()
+            return True
+        except Exception as e:  # pragma: no cover - defensive
+            self.context["error"] = str(e)
+            self.context["loading"] = False
+            self._update_context()
+            return False
+
+    def get_ast_tree(self) -> Optional[ASTNode]:
+        return self.ast_root
+
+    def get_flattened_layout(self) -> List[FlattenedNode]:
+        return self.flattened_nodes
+
+    def switch_display_mode(self, mode: str):
+        self.context["display_mode"] = mode
+        self.context["expanded_nodes"] = ["root"]
+        self.context["selected_node"] = None
+        self._update_context()
+
+    def get_display_nodes(self, mode: Optional[str] = None) -> List[Dict[str, Any]]:
+        if mode is None:
+            mode = self.context.get("display_mode", "tree")
+        if mode == "tree":
+            return self._convert_ast_to_tree_nodes()
+        return self._convert_flattened_to_tree_nodes()
+
+    # --- internal helpers -------------------------------------------------
+    def _convert_ast_to_tree_nodes(self) -> List[Dict[str, Any]]:
+        if not self.ast_root:
+            return []
+        return [self._ast_node_to_dict(self.ast_root)]
+
+    def _ast_node_to_dict(self, node: ASTNode) -> Dict[str, Any]:
+        return {
+            "id": node.id,
+            "label": self._generate_node_label(node),
+            "type": node.type,
+            "children": [self._ast_node_to_dict(c) for c in node.children],
+            "icon": self._get_node_icon(node),
+            "extra": self._get_node_extra(node),
+        }
+
+    def _generate_node_label(self, node: ASTNode) -> str:
+        if node.is_anonymous:
+            return f"(anonymous {node.type})"
+        if node.is_array:
+            dims = "".join(f"[{d}]" for d in node.array_dims)
+            return f"{node.name}{dims}: {node.type}"
+        if node.is_bitfield:
+            return f"{node.name}: {node.type} : {node.bit_size}"
+        return f"{node.name}: {node.type}"
+
+    def _get_node_icon(self, node: ASTNode) -> str:
+        if node.is_struct:
+            return "struct"
+        if node.is_union:
+            return "union"
+        if node.is_array:
+            return "array"
+        if node.is_bitfield:
+            return "bitfield"
+        return "field"
+
+    def _get_node_extra(self, node: ASTNode) -> Dict[str, Any]:
+        return {
+            "offset": node.offset,
+            "size": node.size,
+            "alignment": node.alignment,
+            "is_anonymous": node.is_anonymous,
+        }
+
+    def _convert_flattened_to_tree_nodes(self) -> List[Dict[str, Any]]:
+        result = []
+        for idx, n in enumerate(self.flattened_nodes):
+            result.append({
+                "id": f"flat.{idx}",
+                "label": f"{n.name}: {n.type}",
+                "type": n.type,
+                "children": [],
+                "icon": "field",
+                "extra": {
+                    "offset": n.offset,
+                    "size": n.size,
+                    "bit_size": n.bit_size,
+                    "bit_offset": n.bit_offset,
+                },
+            })
+        return result
+
+    def _update_context(self):
+        if self.view and hasattr(self.view, "update_display"):
+            nodes = self.get_display_nodes(self.context.get("display_mode", "tree"))
+            self.view.update_display(nodes, self.context.copy())
+

--- a/src/view/struct_view.py
+++ b/src/view/struct_view.py
@@ -145,7 +145,7 @@ class StructView(tk.Tk):
         # GUI 版本切換
         tk.Label(control_frame, text="  GUI 版本：").pack(side=tk.LEFT)
         self.gui_version_var = tk.StringVar(value="legacy")
-        gui_version_options = ["legacy", "modern"]
+        gui_version_options = ["legacy", "modern", "v7"]
         self.gui_version_menu = tk.OptionMenu(control_frame, self.gui_version_var, *gui_version_options, command=self._on_gui_version_change)
         self.gui_version_menu.pack(side=tk.LEFT)
         # 搜尋輸入框
@@ -1441,10 +1441,10 @@ class StructView(tk.Tk):
             self.presenter.on_switch_gui_version(version)
         
         # 切換顯示模式
-        if version == "modern":
-            self._switch_to_modern_gui()
-        else:  # legacy
+        if version == "legacy":
             self._switch_to_legacy_gui()
+        else:
+            self._switch_to_modern_gui()
 
     def _switch_to_legacy_gui(self):
         """切換到舊版平面顯示"""

--- a/tests/presenter/test_v7_presenter.py
+++ b/tests/presenter/test_v7_presenter.py
@@ -1,0 +1,28 @@
+"""Tests for the V7Presenter class."""
+
+from src.presenter.v7_presenter import V7Presenter
+
+
+class TestV7Presenter:
+    def test_load_struct_and_get_layout(self):
+        content = """
+        struct Simple {
+            int x;
+            char y;
+        };
+        """
+        presenter = V7Presenter()
+        assert presenter.load_struct_definition(content) is True
+        ast = presenter.get_ast_tree()
+        assert ast is not None
+        assert ast.name == "Simple"
+        layout = presenter.get_flattened_layout()
+        assert len(layout) == 2
+        assert presenter.context["loading"] is False
+        assert presenter.context["error"] is None
+
+    def test_load_struct_failure(self):
+        presenter = V7Presenter()
+        assert presenter.load_struct_definition("not a struct") is False
+        assert presenter.context["error"] is not None
+

--- a/tests/view/test_struct_view.py
+++ b/tests/view/test_struct_view.py
@@ -179,7 +179,7 @@ class PresenterStub:
             self.view.update_display(self._nodes, self.context)
     def on_switch_gui_version(self, version):
         """處理 GUI 版本切換事件"""
-        if version not in ["legacy", "modern"]:
+        if version not in ["legacy", "modern", "v7"]:
             raise ValueError(f"Invalid GUI version: {version}")
         self.context["gui_version"] = version
         # 切換時重置一些狀態


### PR DESCRIPTION
## Summary
- implement `V7Presenter` with AST and layout management
- export new presenter in packages
- add v7 GUI mode and handle switching
- allow test stub to accept v7
- add tests for V7Presenter

## Testing
- `python run_all_tests.py`

------
https://chatgpt.com/codex/tasks/task_e_68805fa335c0832694cbbe642bbd4b02