### PR TITLE
Add v7 presenter GUI switch

### DIFF
--- a/src/presenter/v7_presenter.py
+++ b/src/presenter/v7_presenter.py
@@ -72,6 +72,13 @@ class V7Presenter:
         self.context["selected_node"] = None
         self._update_context()
 
+    def on_switch_gui_version(self, version: str):
+        """Update context when the view switches GUI version."""
+        self.context["gui_version"] = version
+        self.context["expanded_nodes"] = ["root"]
+        self.context["selected_node"] = None
+        self._update_context()
+
     def get_display_nodes(self, mode: Optional[str] = None) -> List[Dict[str, Any]]:
         if mode is None:
             mode = self.context.get("display_mode", "tree")

--- a/src/view/struct_view.py
+++ b/src/view/struct_view.py
@@ -1443,6 +1443,10 @@ class StructView(tk.Tk):
         # 切換顯示模式
         if version == "legacy":
             self._switch_to_legacy_gui()
+        elif version == "modern":
+            self._switch_to_modern_gui()
+        elif version == "v7":
+            self._switch_to_v7_gui()
         else:
             self._switch_to_modern_gui()
 
@@ -1463,6 +1467,10 @@ class StructView(tk.Tk):
             self.modern_frame.pack(fill="both", expand=True)
         else:
             self._create_modern_gui()
+
+    def _switch_to_v7_gui(self):
+        """切換到 v7 版本 GUI。當前實作與新版 GUI 相同。"""
+        self._switch_to_modern_gui()
 
     def _create_modern_gui(self):
         """建立新版樹狀顯示 GUI"""

--- a/tests/view/test_struct_view.py
+++ b/tests/view/test_struct_view.py
@@ -1959,6 +1959,10 @@ class TestStructView(unittest.TestCase):
         # 測試切換到新版
         self.view._on_gui_version_change("modern")
         self.assertEqual(self.presenter.context["gui_version"], "modern")
+
+        # 測試切換到 v7
+        self.view._on_gui_version_change("v7")
+        self.assertEqual(self.presenter.context["gui_version"], "v7")
         
         # 測試切換到舊版
         self.view._on_gui_version_change("legacy")


### PR DESCRIPTION
## Summary
- expose `V7Presenter` GUI switching
- support v7 mode in StructView
- test GUI version switching for v7

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880637208b88326bd2cf4fa40dc61dc