### PR TITLE
Enhance tree switching logic for v7 view

### DIFF
--- a/src/view/struct_view.py
+++ b/src/view/struct_view.py
@@ -192,6 +192,7 @@ class StructView(tk.Tk):
         member_frame = tk.LabelFrame(main_frame, text="Struct Member Value")
         member_frame.pack(fill="x", padx=2, pady=2)
         self.member_tree = create_member_treeview(member_frame)
+        self.legacy_tree = self.member_tree  # keep reference to legacy tree
         self._bind_member_tree_events()
 
         # debug bytes 顯示區
@@ -1455,8 +1456,11 @@ class StructView(tk.Tk):
         # 隱藏新版元件，顯示舊版元件
         if hasattr(self, "modern_frame"):
             self.modern_frame.pack_forget()
+        if hasattr(self, "legacy_tree"):
+            self.member_tree = self.legacy_tree
         if hasattr(self, "member_tree"):
             self.member_tree.pack(fill="x")
+            self._bind_member_tree_events()
 
     def _switch_to_modern_gui(self):
         """切換到新版樹狀顯示"""
@@ -1467,6 +1471,9 @@ class StructView(tk.Tk):
             self.modern_frame.pack(fill="both", expand=True)
         else:
             self._create_modern_gui()
+        if hasattr(self, "modern_tree"):
+            self.member_tree = self.modern_tree
+            self._bind_member_tree_events()
 
     def _switch_to_v7_gui(self):
         """切換到 v7 版本 GUI。當前實作與新版 GUI 相同。"""

--- a/src/view/struct_view_v7.py
+++ b/src/view/struct_view_v7.py
@@ -17,6 +17,8 @@ class StructViewV7(StructView):
         super()._switch_to_modern_gui()
         if hasattr(self, "modern_tree"):
             self.virtual = VirtualTreeview(self.modern_tree, self._virtual_page_size)
+            self.member_tree = self.modern_tree
+            self._bind_member_tree_events()
 
     # override to load nodes into virtual tree
     def show_treeview_nodes(self, nodes, context, icon_map=None):

--- a/tests/view/test_struct_view_v7.py
+++ b/tests/view/test_struct_view_v7.py
@@ -79,3 +79,9 @@ class TestStructViewV7:
         self.view.show_treeview_nodes(nodes, ctx)
         assert "highlighted" in self.view.modern_tree.item("a", "tags")
 
+    def test_switch_sets_active_tree_and_bindings(self):
+        self.view._switch_to_v7_gui()
+        assert self.view.member_tree is self.view.modern_tree
+        # context menu binding should exist on active tree
+        assert self.view.member_tree.bind("<Button-3>")
+


### PR DESCRIPTION
## Summary
- keep reference to legacy tree
- ensure member_tree updates when switching GUI versions
- bind context menu after switching to v7 view
- test that v7 GUI activates modern tree and bindings

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880903f3cb4832688d42454a0cd076b