### PR TITLE
Add virtual tree improvements and GUI shortcuts

### DIFF
--- a/src/view/struct_view_v7.py
+++ b/src/view/struct_view_v7.py
@@ -60,6 +60,7 @@ class StructViewV7(StructView):
         self.bind_all("<Control-f>", lambda e: self.search_entry.focus_set())
         self.bind_all("<Control-l>", lambda e: self.filter_entry.focus_set())
         self.bind_all("<Delete>", lambda e: self._on_batch_delete())
+        self.bind_all("<Control-a>", lambda e: self._select_all_nodes())
 
     # context menu for nodes
     def _bind_member_tree_events(self):
@@ -70,6 +71,8 @@ class StructViewV7(StructView):
     def _show_node_menu(self, event, test_mode=False):
         tree = self.member_tree
         item = tree.identify_row(event.y)
+        if item:
+            tree.selection_set(item)
         menu = tk.Menu(tree, tearoff=0)
         menu.add_command(label="Expand", command=lambda: self.presenter.on_expand(item) if self.presenter else None)
         menu.add_command(label="Collapse", command=lambda: self.presenter.on_collapse(item) if self.presenter else None)
@@ -78,4 +81,13 @@ class StructViewV7(StructView):
         self._node_menu = menu
         if not test_mode:
             menu.tk_popup(event.x_root, event.y_root)
+
+    def _select_all_nodes(self):
+        tree = self.member_tree
+        def collect(parent=""):
+            ids = list(tree.get_children(parent))
+            for i in list(ids):
+                ids.extend(collect(i))
+            return ids
+        tree.selection_set(collect())
 

--- a/src/view/virtual_tree.py
+++ b/src/view/virtual_tree.py
@@ -31,6 +31,7 @@ class VirtualTreeview:
         return "break"
 
     def _render(self):
+        selected = set(self.tree.selection())
         self.tree.delete(*self.tree.get_children())
         end = self.start + self.page_size
         for n in self.nodes[self.start:end]:
@@ -49,3 +50,7 @@ class VirtualTreeview:
                 values=values,
                 tags=tags,
             )
+        # restore selection if possible
+        keep = [i for i in selected if i in self.tree.get_children()]
+        if keep:
+            self.tree.selection_set(keep)

--- a/tests/view/test_struct_view_v7.py
+++ b/tests/view/test_struct_view_v7.py
@@ -85,3 +85,29 @@ class TestStructViewV7:
         # context menu binding should exist on active tree
         assert self.view.member_tree.bind("<Button-3>")
 
+    def test_select_all_shortcut(self):
+        self.view._switch_to_v7_gui()
+        tree = self.view.member_tree
+        for i in range(3):
+            tree.insert('', 'end', iid=f'n{i}', text=f'n{i}')
+        self.view.event_generate('<Control-a>'); self.view.update()
+        assert set(tree.selection()) == set(tree.get_children())
+
+    def test_context_menu_selects_node(self):
+        self.view._switch_to_v7_gui()
+        tree = self.view.member_tree
+        tree.insert('', 'end', iid='x', text='x')
+        tree.update()
+        self.view._show_node_menu(type('E',(object,),{'x_root':0,'y_root':0,'y':0})(), test_mode=True)
+        assert tree.selection() == ('x',)
+
+    def test_scroll_preserves_selection(self):
+        self.view._switch_to_v7_gui()
+        nodes = [{"id": f"n{i}", "name": f"N{i}", "label": f"N{i}", "children": []} for i in range(20)]
+        self.view.show_treeview_nodes(nodes, {"highlighted_nodes": []})
+        tree = self.view.member_tree
+        tree.selection_set('n0')
+        # simulate scroll down
+        self.view.virtual._on_scroll(type('E',(object,),{'delta':-120})())
+        assert 'n0' in tree.selection()
+


### PR DESCRIPTION
## Summary
- maintain selection when virtual tree re-renders
- add Ctrl-A shortcut and node selection on context menu open
- add helper for selecting all nodes
- test new GUI behaviors

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688096905f388326a8fb637a2e52841f