### PR TITLE
Add V7 presenter context and view update test

### DIFF
--- a/src/presenter/v7_presenter.py
+++ b/src/presenter/v7_presenter.py
@@ -31,6 +31,7 @@ class V7Presenter:
             "search": "",
             "filter": "",
             "highlighted_nodes": [],
+            "gui_version": "v7",
             "version": "1.0",
             "extra": {},
             "last_update_time": time.time(),

--- a/tests/presenter/test_v7_presenter.py
+++ b/tests/presenter/test_v7_presenter.py
@@ -71,3 +71,28 @@ class TestV7Presenter:
         assert len(nodes[0]["children"]) == 1
         assert "b" in nodes[0]["children"][0]["label"]
 
+    def test_view_update_on_load(self):
+        class DummyView:
+            def __init__(self):
+                self.called = False
+                self.nodes = None
+                self.context = None
+
+            def update_display(self, nodes, context):
+                self.called = True
+                self.nodes = nodes
+                self.context = context
+
+        content = """
+        struct Foo {
+            int a;
+        };
+        """
+        view = DummyView()
+        presenter = V7Presenter(view=view)
+        assert presenter.context["gui_version"] == "v7"
+        assert presenter.load_struct_definition(content) is True
+        assert view.called is True
+        assert view.nodes
+        assert view.context["loading"] is False
+


### PR DESCRIPTION
## Summary
- set default `gui_version` in `V7Presenter` context
- check that GUI updates on load in V7 presenter tests

## Testing
- `pytest tests/presenter/test_v7_presenter.py::TestV7Presenter::test_view_update_on_load -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880a17c1de8832693aed84ce7d7abba