### PR TITLE
Implement V7 presenter update logic

### DIFF
--- a/src/presenter/v7_presenter.py
+++ b/src/presenter/v7_presenter.py
@@ -191,6 +191,7 @@ class V7Presenter:
         return result
 
     def _update_context(self):
+        self.context["last_update_time"] = time.time()
         if self.view and hasattr(self.view, "update_display"):
             nodes = self.get_display_nodes(self.context.get("display_mode", "tree"))
             self.view.update_display(nodes, self.context.copy())

--- a/tests/presenter/test_v7_presenter.py
+++ b/tests/presenter/test_v7_presenter.py
@@ -96,3 +96,30 @@ class TestV7Presenter:
         assert view.nodes
         assert view.context["loading"] is False
 
+    def test_switch_display_mode_updates_context(self):
+        class DummyView:
+            def __init__(self):
+                self.called = False
+                self.context = None
+
+            def update_display(self, nodes, context):
+                self.called = True
+                self.context = context
+
+        content = """
+        struct Foo {
+            int a;
+        };
+        """
+        view = DummyView()
+        presenter = V7Presenter(view=view)
+        presenter.load_struct_definition(content)
+
+        prev_time = presenter.context["last_update_time"]
+        presenter.switch_display_mode("flat")
+
+        assert presenter.context["display_mode"] == "flat"
+        assert view.called is True
+        assert view.context["display_mode"] == "flat"
+        assert presenter.context["last_update_time"] >= prev_time
+


### PR DESCRIPTION
## Summary
- update `_update_context` in `V7Presenter` to refresh the timestamp
- add a unit test verifying display mode switching updates the context

## Testing
- `pytest tests/presenter/test_v7_presenter.py::TestV7Presenter::test_switch_display_mode_updates_context -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880a7d8e89483269498b44fcc5ff33b