### PR TITLE
Add ASTNode serialization helpers

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -13,6 +13,7 @@ This directory contains comprehensive documentation for the C++ Struct Memory Pa
 - **[v2_bit_field_design_plan.md](development/v2_bit_field_design_plan.md)** - Bit field support design
 - **[string_refactor_plan.md](development/string_refactor_plan.md)** - String management refactoring
 - **[run_all_tests_usage.md](development/run_all_tests_usage.md)** - Test execution guide
+- **[ast_serialization.md](development/ast_serialization.md)** - ASTNode serialization helpers
 
 ## Analysis Documentation
 

--- a/docs/development/ast_serialization.md
+++ b/docs/development/ast_serialization.md
@@ -1,0 +1,32 @@
+# ASTNode Serialization API
+
+This document describes the serialization helpers available for `ASTNode`.
+
+## JSON serialization
+
+`ASTNode` now provides two methods:
+
+- `to_dict()`: convert the node (and all children) into a plain Python `dict`.
+- `from_dict(data)`: class method which rebuilds an `ASTNode` tree from the
+  dictionary produced by `to_dict()`.
+
+These methods are useful when persisting AST structures in JSON format or
+sending them over the network. All fields of the dataclass are preserved.
+
+Example:
+
+```python
+node = ASTNodeFactory.create_struct_node("MyStruct")
+json_data = json.dumps(node.to_dict())
+restored = ASTNode.from_dict(json.loads(json_data))
+```
+
+## Binary serialization
+
+For quick binary persistence the module exposes two helper functions:
+
+- `dumps(node)` → `bytes`
+- `loads(data)` → `ASTNode`
+
+These wrap Python's `pickle` module and perform a simple binary round‑trip of
+an `ASTNode` instance.

--- a/tests/model/test_ast_node_serialization.py
+++ b/tests/model/test_ast_node_serialization.py
@@ -1,0 +1,30 @@
+import json
+import sys
+import types
+
+# Provide a stub for jsonschema to avoid dependency issues when importing the src package
+sys.modules.setdefault("jsonschema", types.ModuleType("jsonschema"))
+
+from src.model.ast_node import ASTNode, ASTNodeFactory, dumps, loads
+
+
+def _build_sample() -> ASTNode:
+    root = ASTNodeFactory.create_struct_node("Root")
+    child = ASTNodeFactory.create_basic_node("value", "int")
+    root.add_child(child)
+    return root
+
+
+def test_dict_round_trip():
+    node = _build_sample()
+    data = node.to_dict()
+    restored = ASTNode.from_dict(data)
+    assert restored.to_dict() == data
+
+
+def test_binary_round_trip():
+    node = _build_sample()
+    b = dumps(node)
+    restored = loads(b)
+    assert isinstance(restored, ASTNode)
+    assert restored.to_dict() == node.to_dict()


### PR DESCRIPTION
## Summary
- add `to_dict()` and `from_dict()` methods to `ASTNode`
- expose `dumps()` and `loads()` helper functions using `pickle`
- document serialization API under `docs/development`
- add unit tests for round-trip serialization

## Testing
- `pytest tests/model/test_ast_node_serialization.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6880c329ad408326877f8e907752ad48