### PR TITLE
Enable v7 GUI mode

### DIFF
--- a/docs/development/v6_GUI_view.md
+++ b/docs/development/v6_GUI_view.md
@@ -325,7 +325,7 @@ def _create_modern_gui(self):
 ### 4. Context 擴充
 ```python
 # 在 context schema 中新增
-"gui_version": {"type": "string", "enum": ["legacy", "modern"]}
+"gui_version": {"type": "string", "enum": ["legacy", "modern", "v7"]}
 ```
 
 ### 5. 實作步驟（按照策略文件）

--- a/src/presenter/context_schema.py
+++ b/src/presenter/context_schema.py
@@ -5,7 +5,7 @@ PRESENTER_CONTEXT_SCHEMA = {
     "type": "object",
     "properties": {
         "display_mode": {"type": "string"},
-        "gui_version": {"type": "string", "enum": ["legacy", "modern"]},
+        "gui_version": {"type": "string", "enum": ["legacy", "modern", "v7"]},
         "expanded_nodes": {"type": "array", "items": {"type": "string"}},
         "selected_node": {"anyOf": [{"type": "string"}, {"type": "null"}]},
         "error": {"anyOf": [{"type": "string"}, {"type": "null"}]},

--- a/src/presenter/struct_presenter.py
+++ b/src/presenter/struct_presenter.py
@@ -483,7 +483,7 @@ class StructPresenter:
     @event_handler("on_switch_gui_version")
     def on_switch_gui_version(self, version):
         """處理 GUI 版本切換事件"""
-        if version not in ["legacy", "modern"]:
+        if version not in ["legacy", "modern", "v7"]:
             raise ValueError(f"Invalid GUI version: {version}")
         self.context["gui_version"] = version
         # 切換時重置一些狀態

--- a/tests/presenter/test_context_schema.py
+++ b/tests/presenter/test_context_schema.py
@@ -44,6 +44,30 @@ class TestPresenterContextSchema(unittest.TestCase):
         with self.assertRaises(Exception):
             validate_presenter_context(context)
 
+    def test_v7_gui_version_allowed(self):
+        context = {
+            "display_mode": "tree",
+            "gui_version": "v7",
+            "expanded_nodes": ["root"],
+            "selected_node": None,
+            "error": None,
+            "filter": None,
+            "search": None,
+            "version": "1.0",
+            "extra": {},
+            "loading": False,
+            "history": [],
+            "user_settings": {},
+            "last_update_time": time.time(),
+            "readonly": False,
+            "pending_action": None,
+            "debug_info": {}
+        }
+        try:
+            validate_presenter_context(context)
+        except Exception as e:
+            self.fail(f"v7 gui_version should be allowed: {e}")
+
     def test_wrong_type(self):
         context = {
             "display_mode": "tree",


### PR DESCRIPTION
## Summary
- allow v7 in presenter context schema
- permit switching to v7 in `StructPresenter`
- document that `gui_version` schema now supports v7
- test that v7 passes schema validation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68826745f1448326a9ec9bac88c30cf9