### PR TITLE
Update view refresh logic when switching to modern GUI

### DIFF
--- a/src/view/struct_view.py
+++ b/src/view/struct_view.py
@@ -1474,6 +1474,15 @@ class StructView(tk.Tk):
         if hasattr(self, "modern_tree"):
             self.member_tree = self.modern_tree
             self._bind_member_tree_events()
+        # 切換後立即刷新顯示內容
+        if (self.presenter and hasattr(self.presenter, "get_display_nodes")
+                and hasattr(self.presenter, "context")):
+            mode = self.presenter.context.get("display_mode", "tree")
+            try:
+                nodes = self.presenter.get_display_nodes(mode)
+            except Exception:
+                nodes = []
+            self.update_display(nodes, self.presenter.context)
 
     def _switch_to_v7_gui(self):
         """切換到 v7 版本 GUI。當前實作與新版 GUI 相同。"""


### PR DESCRIPTION
## Summary
- refresh display in `_switch_to_modern_gui`
- test that parsed results persist when switching GUI versions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688269158e288326915d11fceaaec018