### PR TITLE
Integrate v7 GUI features into StructView

### DIFF
--- a/src/view/struct_view_v7.py
+++ b/src/view/struct_view_v7.py
@@ -1,93 +1,9 @@
-from tkinter import ttk
-import tkinter as tk
-
-from .struct_view import StructView, update_treeview_by_context
-from .virtual_tree import VirtualTreeview
-
+from .struct_view import StructView
 
 class StructViewV7(StructView):
-    """Modern view with virtualized tree rendering and shortcuts."""
-
+    """Backward-compatible wrapper enabling virtualization by default."""
     def __init__(self, presenter=None, page_size=100):
-        self._virtual_page_size = page_size
-        super().__init__(presenter=presenter)
+        super().__init__(presenter=presenter, enable_virtual=True, virtual_page_size=page_size)
 
     def _switch_to_v7_gui(self):
-        """Use modern GUI and setup virtualization."""
-        super()._switch_to_modern_gui()
-        if hasattr(self, "modern_tree"):
-            self.virtual = VirtualTreeview(self.modern_tree, self._virtual_page_size)
-            self.member_tree = self.modern_tree
-            self._bind_member_tree_events()
-
-    # override to load nodes into virtual tree
-    def show_treeview_nodes(self, nodes, context, icon_map=None):
-        if hasattr(self, "virtual"):
-            flat = self._flatten_nodes(nodes, context=context)
-            self.virtual.set_nodes(flat)
-            update_treeview_by_context(self.modern_tree, context)
-        else:
-            super().show_treeview_nodes(nodes, context, icon_map)
-
-    def _flatten_nodes(self, nodes, depth=0, context=None):
-        result = []
-        highlighted = set(context.get("highlighted_nodes", [])) if context else set()
-        for n in nodes:
-            n2 = n.copy()
-            n2["label"] = ("  " * depth) + n2.get("label", n2.get("name", ""))
-            tags = []
-            t = n2.get("type")
-            if t == "struct":
-                tags.append("struct")
-            elif t == "union":
-                tags.append("union")
-            elif t == "bitfield":
-                tags.append("bitfield")
-            elif t == "array":
-                tags.append("array")
-            if n2.get("id") in highlighted:
-                tags.append("highlighted")
-            if tags:
-                n2["tags"] = tags
-            result.append(n2)
-            if n.get("children"):
-                result.extend(self._flatten_nodes(n["children"], depth + 1, context))
-        return result
-
-    # keyboard shortcuts
-    def _init_presenter_view_binding(self):
-        super()._init_presenter_view_binding()
-        self.bind_all("<Control-f>", lambda e: self.search_entry.focus_set())
-        self.bind_all("<Control-l>", lambda e: self.filter_entry.focus_set())
-        self.bind_all("<Delete>", lambda e: self._on_batch_delete())
-        self.bind_all("<Control-a>", lambda e: self._select_all_nodes())
-
-    # context menu for nodes
-    def _bind_member_tree_events(self):
-        super()._bind_member_tree_events()
-        if hasattr(self, "member_tree"):
-            self.member_tree.bind("<Button-3>", lambda e: self._show_node_menu(e))
-
-    def _show_node_menu(self, event, test_mode=False):
-        tree = self.member_tree
-        item = tree.identify_row(event.y)
-        if item:
-            tree.selection_set(item)
-        menu = tk.Menu(tree, tearoff=0)
-        menu.add_command(label="Expand", command=lambda: self.presenter.on_expand(item) if self.presenter else None)
-        menu.add_command(label="Collapse", command=lambda: self.presenter.on_collapse(item) if self.presenter else None)
-        menu.add_separator()
-        menu.add_command(label="Delete", command=self._on_batch_delete)
-        self._node_menu = menu
-        if not test_mode:
-            menu.tk_popup(event.x_root, event.y_root)
-
-    def _select_all_nodes(self):
-        tree = self.member_tree
-        def collect(parent=""):
-            ids = list(tree.get_children(parent))
-            for i in list(ids):
-                ids.extend(collect(i))
-            return ids
-        tree.selection_set(collect())
-
+        self._switch_to_modern_gui()

--- a/tests/view/test_struct_view_v7.py
+++ b/tests/view/test_struct_view_v7.py
@@ -8,7 +8,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..', 'src'))
 pytestmark = pytest.mark.skipif(
     not os.environ.get('DISPLAY'), reason="No display found, skipping GUI tests")
 
-from src.view.struct_view_v7 import StructViewV7
+from src.view.struct_view import StructView
 
 
 class DummyPresenter:
@@ -39,7 +39,8 @@ class TestStructViewV7:
     def setup_method(self):
         self.root = tk.Tk(); self.root.withdraw()
         self.presenter = DummyPresenter()
-        self.view = StructViewV7(presenter=self.presenter, page_size=10)
+        self.view = StructView(presenter=self.presenter, enable_virtual=True,
+                              virtual_page_size=10)
         self.view.update()
 
     def teardown_method(self):
@@ -48,7 +49,7 @@ class TestStructViewV7:
     def test_virtual_tree_limits_nodes(self):
         nodes = [{"id": f"n{i}", "name": f"N{i}", "label": f"N{i}", "children": []} for i in range(50)]
         context = {"highlighted_nodes": []}
-        self.view._switch_to_v7_gui()
+        self.view._switch_to_modern_gui()
         self.view.show_treeview_nodes(nodes, context)
         assert len(self.view.modern_tree.get_children()) <= 10
 
@@ -65,7 +66,7 @@ class TestStructViewV7:
         assert self.view.focus_get() is self.view.search_entry
 
     def test_context_menu_calls_presenter(self):
-        self.view._switch_to_v7_gui()
+        self.view._switch_to_modern_gui()
         tree = self.view.member_tree
         tree.insert('', 'end', iid='x', text='x')
         tree.update()
@@ -75,18 +76,18 @@ class TestStructViewV7:
     def test_highlight_nodes(self):
         nodes = [{"id": "a", "name": "A", "label": "A", "children": []}]
         ctx = {"highlighted_nodes": ["a"]}
-        self.view._switch_to_v7_gui()
+        self.view._switch_to_modern_gui()
         self.view.show_treeview_nodes(nodes, ctx)
         assert "highlighted" in self.view.modern_tree.item("a", "tags")
 
     def test_switch_sets_active_tree_and_bindings(self):
-        self.view._switch_to_v7_gui()
+        self.view._switch_to_modern_gui()
         assert self.view.member_tree is self.view.modern_tree
         # context menu binding should exist on active tree
         assert self.view.member_tree.bind("<Button-3>")
 
     def test_select_all_shortcut(self):
-        self.view._switch_to_v7_gui()
+        self.view._switch_to_modern_gui()
         tree = self.view.member_tree
         for i in range(3):
             tree.insert('', 'end', iid=f'n{i}', text=f'n{i}')
@@ -94,7 +95,7 @@ class TestStructViewV7:
         assert set(tree.selection()) == set(tree.get_children())
 
     def test_context_menu_selects_node(self):
-        self.view._switch_to_v7_gui()
+        self.view._switch_to_modern_gui()
         tree = self.view.member_tree
         tree.insert('', 'end', iid='x', text='x')
         tree.update()
@@ -102,7 +103,7 @@ class TestStructViewV7:
         assert tree.selection() == ('x',)
 
     def test_scroll_preserves_selection(self):
-        self.view._switch_to_v7_gui()
+        self.view._switch_to_modern_gui()
         nodes = [{"id": f"n{i}", "name": f"N{i}", "label": f"N{i}", "children": []} for i in range(20)]
         self.view.show_treeview_nodes(nodes, {"highlighted_nodes": []})
         tree = self.view.member_tree


### PR DESCRIPTION
## Summary
- merge VirtualTreeview behavior into StructView
- keep StructViewV7 as thin compatibility wrapper
- update virtualization tests to use StructView

## Testing
- `pytest -k test_struct_view_v7 -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688509b07c888326ae6ff0e54fa06088