### PR TITLE
Add shared layout treeview helper

### DIFF
--- a/src/view/struct_view.py
+++ b/src/view/struct_view.py
@@ -14,6 +14,17 @@ MEMBER_TREEVIEW_COLUMNS = [
     {"name": "hex_raw", "title": "Hex Raw", "width": 150},
 ]
 
+# Columns for struct layout treeviews
+LAYOUT_TREEVIEW_COLUMNS = [
+    {"name": "name", "title": "欄位名稱", "width": 120},
+    {"name": "type", "title": "型別", "width": 100},
+    {"name": "offset", "title": "Offset", "width": 80},
+    {"name": "size", "title": "Size", "width": 80},
+    {"name": "bit_offset", "title": "bit_offset", "width": 80},
+    {"name": "bit_size", "title": "bit_size", "width": 80},
+    {"name": "is_bitfield", "title": "is_bitfield", "width": 80},
+]
+
 def create_member_treeview(parent):
     all_columns = MEMBER_TREEVIEW_COLUMNS
     col_names = tuple(c["name"] for c in all_columns)
@@ -29,6 +40,25 @@ def create_member_treeview(parent):
         tree.column(c["name"], width=c["width"], stretch=False)
     tree["displaycolumns"] = col_names
     tree.pack(fill="x")
+    return tree
+
+
+def create_layout_treeview(parent, yscrollcommand=None):
+    """Create a Treeview for struct layout display."""
+    all_columns = LAYOUT_TREEVIEW_COLUMNS
+    col_names = tuple(c["name"] for c in all_columns)
+    tree = ttk.Treeview(
+        parent,
+        columns=col_names,
+        show="headings",
+        height=10,
+        yscrollcommand=yscrollcommand,
+    )
+    for c in all_columns:
+        tree.heading(c["name"], text=c["title"])
+        tree.column(c["name"], width=c["width"], stretch=False)
+    tree["displaycolumns"] = col_names
+    tree.pack(side="left", fill="both", expand=True)
     return tree
 
 def update_treeview_by_context(tree, context):
@@ -209,15 +239,7 @@ class StructView(tk.Tk):
         layout_frame.pack(fill="both", expand=True, padx=2, pady=2)
         # 新增 scroll bar
         layout_scrollbar = ttk.Scrollbar(layout_frame, orient="vertical")
-        self.layout_tree = ttk.Treeview(layout_frame, columns=("name", "type", "offset", "size", "bit_offset", "bit_size", "is_bitfield"), show="headings", height=10, yscrollcommand=layout_scrollbar.set)
-        self.layout_tree.heading("name", text="欄位名稱")
-        self.layout_tree.heading("type", text="型別")
-        self.layout_tree.heading("offset", text="Offset")
-        self.layout_tree.heading("size", text="Size")
-        self.layout_tree.heading("bit_offset", text="bit_offset")
-        self.layout_tree.heading("bit_size", text="bit_size")
-        self.layout_tree.heading("is_bitfield", text="is_bitfield")
-        self.layout_tree.pack(side="left", fill="both", expand=True)
+        self.layout_tree = create_layout_treeview(layout_frame, yscrollcommand=layout_scrollbar.set)
         layout_scrollbar.config(command=self.layout_tree.yview)
         layout_scrollbar.pack(side="right", fill="y")
 
@@ -294,15 +316,7 @@ class StructView(tk.Tk):
         layout_frame = tk.LabelFrame(scrollable_frame, text="Struct Layout (標準顯示)")
         layout_frame.pack(fill="both", expand=True, padx=2, pady=2)
         layout_scrollbar = ttk.Scrollbar(layout_frame, orient="vertical")
-        self.manual_layout_tree = ttk.Treeview(layout_frame, columns=("name", "type", "offset", "size", "bit_offset", "bit_size", "is_bitfield"), show="headings", height=10, yscrollcommand=layout_scrollbar.set)
-        self.manual_layout_tree.heading("name", text="欄位名稱")
-        self.manual_layout_tree.heading("type", text="型別")
-        self.manual_layout_tree.heading("offset", text="Offset")
-        self.manual_layout_tree.heading("size", text="Size")
-        self.manual_layout_tree.heading("bit_offset", text="bit_offset")
-        self.manual_layout_tree.heading("bit_size", text="bit_size")
-        self.manual_layout_tree.heading("is_bitfield", text="is_bitfield")
-        self.manual_layout_tree.pack(side="left", fill="both", expand=True)
+        self.manual_layout_tree = create_layout_treeview(layout_frame, yscrollcommand=layout_scrollbar.set)
         layout_scrollbar.config(command=self.manual_layout_tree.yview)
         layout_scrollbar.pack(side="right", fill="y")
 

--- a/tests/view/test_struct_view.py
+++ b/tests/view/test_struct_view.py
@@ -14,7 +14,7 @@ pytestmark = pytest.mark.skipif(
     not os.environ.get('DISPLAY'), reason="No display found, skipping GUI tests"
 )
 
-from src.view.struct_view import StructView, create_member_treeview
+from src.view.struct_view import StructView, create_member_treeview, create_layout_treeview
 from src.presenter.struct_presenter import StructPresenter
 from src.model.struct_model import StructModel
 
@@ -1556,6 +1556,19 @@ class TestStructView(unittest.TestCase):
         for col in file_tree.cget("columns"):
             self.assertEqual(file_tree.column(col)["width"], manual_tree.column(col)["width"])
         # tkinter/ttk heading fallback 行為：不同平台/版本查詢 heading text 可能回傳欄位 name 而非 title，故不驗證 heading text。
+
+    def test_layout_treeview_column_config一致(self):
+        """驗證 file tab 與 manual tab 的 layout_tree 欄位名稱、寬度、順序完全一致"""
+        view = self.view
+        presenter = self.presenter
+        nodes = presenter.get_display_nodes(presenter.context.get("display_mode", "tree"))
+        view.update_display(nodes, presenter.context)
+        file_tree = view.layout_tree
+        manual_tree = view.manual_layout_tree
+        self.assertEqual(file_tree.cget("columns"), manual_tree.cget("columns"))
+        self.assertEqual(file_tree.cget("displaycolumns"), manual_tree.cget("displaycolumns"))
+        for col in file_tree.cget("columns"):
+            self.assertEqual(file_tree.column(col)["width"], manual_tree.column(col)["width"])
 
     def test_treeview_drag_reorder_nodes(self):
         """TDD: 驗證 Treeview 拖曳排序（同層級節點順序調整）功能。"""


### PR DESCRIPTION
## Summary
- share config for layout treeviews via `create_layout_treeview`
- ensure file and manual layout tables use the helper
- verify layout treeview column config matches across tabs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68851b40792483269e5836f3327bb886