### PR TITLE
Implement TDD step 1 for input field processor tests

### DIFF
--- a/tests/model/test_input_field_processor.py
+++ b/tests/model/test_input_field_processor.py
@@ -82,5 +82,14 @@ class TestInputFieldProcessorXMLDriven(unittest.TestCase):
                     result = self.processor.convert_to_raw_bytes(subcase['padded_hex'], subcase['byte_size'], subcase['endianness'])
                     self.assertEqual(result.hex(), subcase['expected'].lower())
 
+
+@unittest.skip("XML-driven tests placeholder")
+class TestInputFieldProcessorXML(unittest.TestCase):
+    """Placeholder for new XML-driven tests (TDD step 1)."""
+
+    def test_placeholder(self):
+        """Dummy test to be implemented in later steps."""
+        self.assertTrue(True)
+
 if __name__ == '__main__':
     unittest.main() 


### PR DESCRIPTION
## Summary
- add a placeholder `TestInputFieldProcessorXML` class to begin migration to XML-driven tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68852ef2baa88326b65365308c72880f