### PR TITLE
Implement VirtualTreeview reorder helpers

### DIFF
--- a/src/view/virtual_tree.py
+++ b/src/view/virtual_tree.py
@@ -54,3 +54,20 @@ class VirtualTreeview:
         keep = [i for i in selected if i in self.tree.get_children()]
         if keep:
             self.tree.selection_set(keep)
+
+    def get_global_index(self, iid):
+        """Return the index of ``iid`` within the full node list."""
+        for idx, n in enumerate(self.nodes):
+            if n.get("id") == iid:
+                return idx
+        return -1
+
+    def reorder_nodes(self, parent_id, from_idx, to_idx):
+        """Move node from ``from_idx`` to ``to_idx`` and re-render."""
+        if from_idx < 0 or from_idx >= len(self.nodes):
+            return
+        if to_idx < 0 or to_idx >= len(self.nodes):
+            return
+        node = self.nodes.pop(from_idx)
+        self.nodes.insert(to_idx, node)
+        self._render()

--- a/tests/view/test_struct_view.py
+++ b/tests/view/test_struct_view.py
@@ -2577,5 +2577,17 @@ def test_scroll_preserves_selection(view):
     view.virtual._on_scroll(type('E',(object,),{'delta':-120})())
     assert 'n0' in tree.selection()
 
+
+def test_virtual_tree_reorder_nodes(view):
+    if not view.enable_virtual:
+        pytest.skip("virtual mode only")
+    nodes = [{"id": f"n{i}", "name": f"N{i}", "label": f"N{i}", "children": []} for i in range(3)]
+    ctx = {"highlighted_nodes": []}
+    view._switch_to_modern_gui()
+    view.show_treeview_nodes(nodes, ctx)
+    assert view.virtual.get_global_index("n1") == 1
+    view.virtual.reorder_nodes("", 0, 2)
+    assert list(view.member_tree.get_children("")) == ["n1", "n2", "n0"]
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- add `get_global_index` and `reorder_nodes` to `VirtualTreeview`
- test reorder logic in virtual mode

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68887033d52c8326accceaae05a10a06