### PR TITLE
Read overview and development docs, then develop

### DIFF
--- a/src/model/parser.py
+++ b/src/model/parser.py
@@ -29,7 +29,7 @@ class V7StructParser:
             content = self._clean_content(content)
 
             # 解析聚合型別名稱與種類
-            agg_match = re.match(r'(struct|union)\s+(\w+)\s*\{', content)
+            agg_match = re.match(r'(struct|union)\s+(?:__attribute__\s*\(\(.*?\)\)\s*)*(\w+)\s*\{', content, flags=re.DOTALL)
             if not agg_match:
                 return None
 
@@ -71,7 +71,7 @@ class V7StructParser:
         """
         try:
             # 尋找第一個聚合型別的起始位置
-            agg = re.search(r'(struct|union)\s+\w+\s*\{', content, flags=re.MULTILINE)
+            agg = re.search(r'(struct|union)\s+(?:__attribute__\s*\(\(.*?\)\)\s*)*\w+\s*\{', content, flags=re.MULTILINE | re.DOTALL)
             if not agg:
                 return content, None
 
@@ -89,6 +89,8 @@ class V7StructParser:
                 elif m.group(3):  # pop
                     if pack_stack:
                         pack_stack.pop()
+                    else:
+                        logger.warning("Unmatched '#pragma pack(pop)' encountered before any push")
 
             current_pack = pack_stack[-1] if pack_stack else None
 


### PR DESCRIPTION
Enhance parser to support `__attribute__` on top-level unions and warn for unmatched `#pragma pack(pop)` directives.

This PR implements specific parser improvements outlined in the v9 development documentation. It ensures the parser correctly handles GCC-style attributes on aggregate types and provides better feedback for malformed `#pragma pack` directives, aligning with the planned v9 parser capabilities.

---
<a href="https://cursor.com/background-agent?bcId=bc-af095604-7486-4e0e-9427-57cf2b0c7999">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-af095604-7486-4e0e-9427-57cf2b0c7999">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

