### PR TITLE
Begin development based on v17 documents

### DIFF
--- a/src/presenter/struct_presenter.py
+++ b/src/presenter/struct_presenter.py
@@ -651,3 +651,17 @@ class StructPresenter:
         if hasattr(self.model, "get_display_nodes"):
             return self.model.get_display_nodes(mode)
         return []
+
+    def set_import_target_struct(self, name: str):
+        """v17: 指定要顯示的根 struct/union 名稱，切換並推送 UI。"""
+        if not hasattr(self.model, "set_import_target_struct"):
+            raise AttributeError("Model does not support target struct switching")
+        self.model.set_import_target_struct(name)
+        # 更新 context 可用型別列表（若 model 暴露）
+        types = getattr(self.model, 'available_top_level_types', None)
+        if types is not None:
+            self.context.setdefault('extra', {})['available_top_level_types'] = list(types)
+        # 立即推送
+        self.context["debug_info"]["last_event"] = "set_import_target_struct"
+        self.context["debug_info"]["last_event_args"] = {"name": name}
+        self.push_context()

--- a/tests/model/test_layout_v17_memberdef_only.py
+++ b/tests/model/test_layout_v17_memberdef_only.py
@@ -1,0 +1,47 @@
+import unittest
+from src.model.struct_parser import parse_struct_definition_ast
+from src.model.struct_model import calculate_layout
+
+
+def _names(layout):
+    return [x.name if hasattr(x, 'name') else x.get('name') for x in layout if (hasattr(x, 'type') and x.type != 'padding') or (isinstance(x, dict) and x.get('type') != 'padding')]
+
+
+class TestLayoutV17MemberDefOnly(unittest.TestCase):
+    def test_layout_expands_nd_pointer_array(self):
+        src = '''
+        struct S { int x; };
+        struct W { struct S *nd[2][2]; };
+        '''
+        sdef = parse_struct_definition_ast(src)
+        layout, total, align = calculate_layout(sdef.members)
+        names = _names(layout)
+        # pointer array 展開各元素
+        self.assertIn('nd[0][0]', names)
+        self.assertIn('nd[1][1]', names)
+
+    def test_layout_referenced_struct_array_expand(self):
+        src = '''
+        struct Inner { int x; };
+        struct W { struct Inner arr[2]; };
+        '''
+        sdef = parse_struct_definition_ast(src)
+        layout, total, align = calculate_layout(sdef.members)
+        names = _names(layout)
+        self.assertIn('arr[0].x', names)
+        self.assertIn('arr[1].x', names)
+
+    def test_layout_forward_reference_expand(self):
+        src = '''
+        struct Outer { struct Inner a; };
+        struct Inner { int x; };
+        '''
+        sdef = parse_struct_definition_ast(src, target_name='Outer')
+        layout, total, align = calculate_layout(sdef.members)
+        names = _names(layout)
+        self.assertIn('a.x', names)
+
+
+if __name__ == '__main__':
+    unittest.main()
+

--- a/tests/model/test_model_v17_target_struct.py
+++ b/tests/model/test_model_v17_target_struct.py
@@ -1,0 +1,61 @@
+import os
+import tempfile
+import unittest
+from src.model.struct_model import StructModel
+
+
+SRC = """
+struct Inner { int x; };
+struct Outer { struct Inner a; };
+struct Another { char y; };
+"""
+
+
+class TestModelV17TargetStruct(unittest.TestCase):
+    def _write_temp_header(self, content):
+        fd, path = tempfile.mkstemp(suffix='.h')
+        os.close(fd)
+        with open(path, 'w') as f:
+            f.write(content)
+        return path
+
+    def test_load_struct_from_file_with_target_name_outer(self):
+        path = self._write_temp_header(SRC)
+        try:
+            model = StructModel()
+            name, layout, total, align = model.load_struct_from_file(path, target_name='Outer')
+            self.assertEqual(name, 'Outer')
+        finally:
+            os.remove(path)
+
+    def test_load_struct_from_file_with_target_name_forward(self):
+        src = """
+        struct Outer { struct Inner a; };
+        struct Inner { int x; };
+        """
+        path = self._write_temp_header(src)
+        try:
+            model = StructModel()
+            name, layout, total, align = model.load_struct_from_file(path, target_name='Outer')
+            names = [it.name if hasattr(it, 'name') else it.get('name') for it in layout]
+            self.assertIn('a.x', ''.join(n for n in names if n))
+        finally:
+            os.remove(path)
+
+    def test_available_top_level_types_listed(self):
+        path = self._write_temp_header(SRC)
+        try:
+            model = StructModel()
+            name, layout, total, align = model.load_struct_from_file(path, target_name='Outer')
+            types = getattr(model, 'available_top_level_types', [])
+            self.assertIsInstance(types, list)
+            self.assertTrue(types)
+            self.assertIn('Outer', types)
+            self.assertIn('Inner', types)
+        finally:
+            os.remove(path)
+
+
+if __name__ == '__main__':
+    unittest.main()
+

--- a/tests/model/test_parser_v17_memberdef_only.py
+++ b/tests/model/test_parser_v17_memberdef_only.py
@@ -1,0 +1,43 @@
+import unittest
+from src.model.struct_parser import parse_member_line_v2, parse_struct_definition_ast, MemberDef
+
+
+class TestParserV17MemberDefOnly(unittest.TestCase):
+    def test_scalar_pointer_array_returns_memberdef(self):
+        m1 = parse_member_line_v2('int a')
+        self.assertIsInstance(m1, MemberDef)
+        self.assertEqual(m1.type, 'int')
+        self.assertEqual(m1.name, 'a')
+
+        m2 = parse_member_line_v2('int *p')
+        self.assertIsInstance(m2, MemberDef)
+        self.assertEqual(m2.type, 'pointer')
+        self.assertEqual(m2.name, 'p')
+
+        m3 = parse_member_line_v2('int *arr[2]')
+        self.assertIsInstance(m3, MemberDef)
+        self.assertEqual(m3.type, 'pointer')
+        self.assertEqual(m3.name, 'arr')
+        self.assertEqual(m3.array_dims, [2])
+
+    def test_nd_pointer_array_memberdef_dims_preserved(self):
+        m = parse_member_line_v2('int *nd[2][2]')
+        self.assertIsInstance(m, MemberDef)
+        self.assertEqual(m.type, 'pointer')
+        self.assertEqual(m.name, 'nd')
+        self.assertEqual(m.array_dims, [2, 2])
+
+    def test_referenced_struct_union_memberdef(self):
+        src = '''
+        struct Inner { int x; char y; };
+        union U { int a; char b; };
+        struct Outer { struct Inner i; union U u; };
+        '''
+        sdef = parse_struct_definition_ast(src)
+        self.assertIsNotNone(sdef)
+        self.assertTrue(all(isinstance(m, MemberDef) for m in sdef.members))
+
+
+if __name__ == '__main__':
+    unittest.main()
+

--- a/tests/presenter/test_presenter_v17_target_struct.py
+++ b/tests/presenter/test_presenter_v17_target_struct.py
@@ -1,0 +1,79 @@
+import os
+import tempfile
+import time
+import unittest
+from src.model.struct_model import StructModel
+from src.presenter.struct_presenter import StructPresenter
+
+
+SRC = """
+struct Inner { int x; };
+struct Outer { struct Inner a; };
+struct Last { char z; };
+"""
+
+
+class MockView:
+    def __init__(self):
+        self.last_nodes = None
+        self.last_context = None
+        self.update_display_called = False
+    def update_display(self, nodes, context):
+        self.last_nodes = nodes
+        self.last_context = context
+        self.update_display_called = True
+
+
+class TestPresenterV17TargetStruct(unittest.TestCase):
+    def _write_temp_header(self, content):
+        fd, path = tempfile.mkstemp(suffix='.h')
+        os.close(fd)
+        with open(path, 'w') as f:
+            f.write(content)
+        return path
+
+    def setUp(self):
+        self.model = StructModel()
+        self.view = MockView()
+        self.presenter = StructPresenter(self.model, self.view)
+        # Make push_context synchronous for tests
+        self.presenter._debounce_interval = 0
+        orig_push_context = self.presenter.push_context
+        def sync_push_context(*args, **kwargs):
+            return orig_push_context(immediate=True)
+        self.presenter.push_context = sync_push_context
+
+    def test_set_import_target_struct_switches_root(self):
+        path = self._write_temp_header(SRC)
+        try:
+            # initial load default (last top-level is Last)
+            self.model.load_struct_from_file(path)
+            # switch to Outer
+            self.presenter.set_import_target_struct('Outer')
+            self.assertTrue(self.view.update_display_called)
+            self.assertIsInstance(self.view.last_nodes, list)
+            root = self.view.last_nodes[0]
+            self.assertIn('Outer', root.get('label', ''))
+        finally:
+            os.remove(path)
+
+    def test_presenter_values_are_strings(self):
+        path = self._write_temp_header(SRC)
+        try:
+            self.model.load_struct_from_file(path)
+            self.presenter.set_import_target_struct('Outer')
+            self.assertTrue(self.view.update_display_called)
+            def walk(nodes):
+                for n in nodes:
+                    self.assertIsInstance(n.get('value', ''), str)
+                    self.assertIsInstance(n.get('offset', ''), str)
+                    self.assertIsInstance(n.get('size', ''), str)
+                    walk(n.get('children', []))
+            walk(self.view.last_nodes)
+        finally:
+            os.remove(path)
+
+
+if __name__ == '__main__':
+    unittest.main()
+


### PR DESCRIPTION
Implement v17 data format unification and target struct selection to align with development documents.

This PR introduces the ability to specify a target struct/union when loading a C header file, allowing users to select which top-level definition to analyze. It also enhances the parser to correctly handle various pointer and array declarations, and ensures display data is consistently formatted as strings for the UI.

---
<a href="https://cursor.com/background-agent?bcId=bc-79ca2875-b86c-496e-a5c5-d18efbebe39d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-79ca2875-b86c-496e-a5c5-d18efbebe39d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

