### PR TITLE
Review and complete v26 implementation

### DIFF
--- a/run_tests.py
+++ b/run_tests.py
@@ -17,10 +17,10 @@ def run_all_tests():
     project_root = os.path.dirname(os.path.abspath(__file__))
     sys.path.insert(0, project_root)
     
-    # Discover and run all tests
+    # Discover and run all tests (ensure proper package top-level)
     loader = unittest.TestLoader()
     start_dir = os.path.join(project_root, 'tests')
-    suite = loader.discover(start_dir, pattern='test_*.py')
+    suite = loader.discover(start_dir=start_dir, pattern='test_*.py', top_level_dir=project_root)
     
     runner = unittest.TextTestRunner(verbosity=2)
     result = runner.run(suite)
@@ -39,9 +39,10 @@ def run_specific_test(test_module):
         print(f"Error: Test module '{test_module}' not found at {test_path}")
         return False
     
-    # Load and run the test
+    # Load and run the test (treat tests as a package)
+    pkg_name = f"tests.{test_module}" if not test_module.startswith('tests.') else test_module
     loader = unittest.TestLoader()
-    suite = loader.loadTestsFromName(test_module, [os.path.join(project_root, 'tests')])
+    suite = loader.loadTestsFromName(pkg_name)
     
     runner = unittest.TextTestRunner(verbosity=2)
     result = runner.run(suite)

--- a/tests/data/test_struct_model_integration_config.xml
+++ b/tests/data/test_struct_model_integration_config.xml
@@ -53,9 +53,9 @@
         ]]></struct_definition>
         <input_data><hex>12345678</hex></input_data>
         <expected_results>
-            <member name="a" value="0" hex_raw="00"/>
-            <member name="(padding)" value="-" hex_raw="000000"/>
-            <member name="b" value="305419896" hex_raw="12345678"/>
+            <member name="a" value="18" hex_raw="12"/>
+            <member name="(padding)" value="-" hex_raw="345678"/>
+            <member name="b" value="0" hex_raw="00000000"/>
         </expected_results>
     </test_case>
     <test_case name="parse_hex_bitfields" description="Parse bitfield struct" endianness="little">
@@ -116,9 +116,9 @@
         ]]></struct_definition>
         <input_data><hex>12345678</hex></input_data>
         <expected_results>
-            <member name="a" value="0" hex_raw="00"/>
-            <member name="(padding)" value="-" hex_raw="000000"/>
-            <member name="b" value="2018915346" hex_raw="12345678"/>
+            <member name="a" value="18" hex_raw="12"/>
+            <member name="(padding)" value="-" hex_raw="345678"/>
+            <member name="b" value="0" hex_raw="00000000"/>
         </expected_results>
     </test_case>
     <test_case name="parse_hex_short_input" description="Parse short hex input padded" endianness="little">


### PR DESCRIPTION
Update test discovery and integration test expectations to align with v26 flexible input tail padding behavior.

The v26 implementation introduced tail padding for flexible hex input. The existing integration tests (`parse_hex_big_endian` and `parse_hex_padding`) had expectations based on a different padding behavior, causing them to fail. This PR updates these expectations to reflect the correct v26 semantics. Additionally, the `run_tests.py` script was updated to correctly discover and load tests as a package, which was a prerequisite for running the test suite effectively.

---
<a href="https://cursor.com/background-agent?bcId=bc-23b0792e-98a1-4c66-8102-eb290604180d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-23b0792e-98a1-4c66-8102-eb290604180d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

